### PR TITLE
add the support for displays without a RST pin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod models;
 use models::Model;
 
 mod graphics;
+mod no_pin;
 
 #[cfg(feature = "batch")]
 mod batch;
@@ -53,6 +54,8 @@ where
     // Current orientation
     orientation: Orientation,
 }
+
+pub type DisplayNoRST<DI, MODEL> = Display<DI, no_pin::NoPin, MODEL>;
 
 ///
 /// Display orientation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ use models::Model;
 
 mod graphics;
 mod no_pin;
+pub use no_pin::*;
 
 #[cfg(feature = "batch")]
 mod batch;
@@ -48,14 +49,12 @@ where
     // Display interface
     di: DI,
     // Reset pin.
-    rst: RST,
+    rst: Option<RST>,
     // Model
     model: MODEL,
     // Current orientation
     orientation: Orientation,
 }
-
-pub type DisplayNoRST<DI, MODEL> = Display<DI, no_pin::NoPin, MODEL>;
 
 ///
 /// Display orientation.
@@ -118,7 +117,7 @@ where
     /// * `rst` - display hard reset [OutputPin]
     /// * `model` - the display [Model]
     ///
-    pub fn with_model(di: DI, rst: RST, model: M) -> Self {
+    pub fn with_model(di: DI, rst: Option<RST>, model: M) -> Self {
         Self {
             di,
             rst,
@@ -220,7 +219,7 @@ where
     /// Release resources allocated to this driver back.
     /// This returns the display interface and the RST pin deconstructing the driver.
     ///
-    pub fn release(self) -> (DI, RST, M) {
+    pub fn release(self) -> (DI, Option<RST>, M) {
         (self.di, self.rst, self.model)
     }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -20,7 +20,7 @@ pub trait Model {
     fn init<RST, DELAY>(
         &mut self,
         di: &mut dyn WriteOnlyDataCommand,
-        rst: &mut RST,
+        rst: &mut Option<RST>,
         delay: &mut DELAY,
     ) -> Result<(), Error<RST::Error>>
     where

--- a/src/models/ili9486.rs
+++ b/src/models/ili9486.rs
@@ -29,14 +29,17 @@ impl Model for ILI9486Rgb565 {
     fn init<RST, DELAY>(
         &mut self,
         di: &mut dyn WriteOnlyDataCommand,
-        rst: &mut RST,
+        rst: &mut Option<RST>,
         delay: &mut DELAY,
     ) -> Result<(), Error<RST::Error>>
     where
         RST: OutputPin,
         DELAY: DelayUs<u32>,
     {
-        self.hard_reset(rst, delay)?;
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay)?,
+            None => write_command(di, Instruction::SWRESET, &[])?,
+        }
         delay.delay_us(120_000);
 
         init_common(di, delay).map_err(|_| Error::DisplayError)
@@ -69,14 +72,18 @@ impl Model for ILI9486Rgb666 {
     fn init<RST, DELAY>(
         &mut self,
         di: &mut dyn WriteOnlyDataCommand,
-        rst: &mut RST,
+        rst: &mut Option<RST>,
         delay: &mut DELAY,
     ) -> Result<(), Error<RST::Error>>
     where
         RST: OutputPin,
         DELAY: DelayUs<u32>,
     {
-        self.hard_reset(rst, delay)?;
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay)?,
+            None => write_command(di, Instruction::SWRESET, &[])?,
+        };
+
         delay.delay_us(120_000);
 
         init_common(di, delay).map_err(|_| Error::DisplayError)
@@ -122,7 +129,7 @@ where
     /// * `model` - the display [Model]
     ///
     pub fn ili9486_rgb565(di: DI, rst: RST) -> Self {
-        Self::with_model(di, rst, ILI9486Rgb565::new())
+        Self::with_model(di, Some(rst), ILI9486Rgb565::new())
     }
 }
 
@@ -141,7 +148,7 @@ where
     /// * `model` - the display [Model]
     ///
     pub fn ili9486_rgb666(di: DI, rst: RST) -> Self {
-        Self::with_model(di, rst, ILI9486Rgb666::new())
+        Self::with_model(di, Some(rst), ILI9486Rgb666::new())
     }
 }
 

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -98,7 +98,7 @@ where
     DI: WriteOnlyDataCommand,
 {
     ///
-    /// Creates a new [Display] instance with [ST7789] as the [Model] and without
+    /// Creates a new [Display] instance with [ST7789] as the [Model] without
     /// a hard reset Pin
     ///
     /// # Arguments

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -3,7 +3,6 @@ use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 use crate::no_pin::NoPin;
-use crate::DisplayNoRST;
 use crate::{instruction::Instruction, Display, Error};
 
 use super::{write_command, Model};
@@ -22,15 +21,18 @@ impl Model for ST7789 {
     fn init<RST, DELAY>(
         &mut self,
         di: &mut dyn WriteOnlyDataCommand,
-        rst: &mut RST,
+        rst: &mut Option<RST>,
         delay: &mut DELAY,
     ) -> Result<(), Error<RST::Error>>
     where
         RST: OutputPin,
         DELAY: DelayUs<u32>,
     {
-        self.hard_reset(rst, delay)?;
-        delay.delay_us(120_000);
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay)?,
+            None => write_command(di, Instruction::SWRESET, &[])?,
+        }
+        delay.delay_us(150_000);
 
         write_command(di, Instruction::SLPOUT, &[])?; // turn off sleep
 
@@ -87,11 +89,11 @@ where
     /// * `model` - the display [Model]
     ///
     pub fn st7789(di: DI, rst: RST) -> Self {
-        Self::with_model(di, rst, ST7789::new())
+        Self::with_model(di, Some(rst), ST7789::new())
     }
 }
 
-impl<DI> DisplayNoRST<DI, ST7789>
+impl<DI> Display<DI, NoPin, ST7789>
 where
     DI: WriteOnlyDataCommand,
 {
@@ -105,6 +107,6 @@ where
     /// * `model` - the display [Model]
     ///
     pub fn st7789_without_rst(di: DI) -> Self {
-        Self::with_model(di, NoPin::default(), ST7789::new())
+        Self::with_model(di, None, ST7789::new())
     }
 }

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -2,6 +2,8 @@ use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
 use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
+use crate::no_pin::NoPin;
+use crate::DisplayNoRST;
 use crate::{instruction::Instruction, Display, Error};
 
 use super::{write_command, Model};
@@ -75,7 +77,8 @@ where
     RST: OutputPin,
 {
     ///
-    /// Creates a new [Display] instance with [ST7789] as the [Model]
+    /// Creates a new [Display] instance with [ST7789] as the [Model] with a
+    /// hard reset Pin
     ///
     /// # Arguments
     ///
@@ -85,5 +88,23 @@ where
     ///
     pub fn st7789(di: DI, rst: RST) -> Self {
         Self::with_model(di, rst, ST7789::new())
+    }
+}
+
+impl<DI> DisplayNoRST<DI, ST7789>
+where
+    DI: WriteOnlyDataCommand,
+{
+    ///
+    /// Creates a new [Display] instance with [ST7789] as the [Model] and without
+    /// a hard reset Pin
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `model` - the display [Model]
+    ///
+    pub fn st7789_without_rst(di: DI) -> Self {
+        Self::with_model(di, NoPin::default(), ST7789::new())
     }
 }

--- a/src/no_pin.rs
+++ b/src/no_pin.rs
@@ -3,7 +3,7 @@ use embedded_hal::digital::v2::{OutputPin, PinState};
 use core::convert::Infallible;
 
 #[derive(Default)]
-pub struct NoPin {}
+pub struct NoPin;
 
 impl OutputPin for NoPin {
     type Error = Infallible;
@@ -11,6 +11,7 @@ impl OutputPin for NoPin {
     fn set_low(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
+    
     fn set_high(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }

--- a/src/no_pin.rs
+++ b/src/no_pin.rs
@@ -1,0 +1,21 @@
+use embedded_hal::digital::v2::{OutputPin, PinState};
+
+use core::convert::Infallible;
+
+#[derive(Default)]
+pub struct NoPin {}
+
+impl OutputPin for NoPin {
+    type Error = Infallible;
+
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn set_state(&mut self, _state: PinState) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}

--- a/src/no_pin.rs
+++ b/src/no_pin.rs
@@ -2,6 +2,9 @@ use embedded_hal::digital::v2::{OutputPin, PinState};
 
 use core::convert::Infallible;
 
+/// The NoPin struct is here as a dummy implementation of the OutputPin trait
+/// to handle the case when devices do not have a RST Pin and remove the need
+/// for the user to use a real Pin as a fake one in this case.
 #[derive(Default)]
 pub struct NoPin;
 
@@ -11,7 +14,7 @@ impl OutputPin for NoPin {
     fn set_low(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
-    
+
     fn set_high(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }


### PR DESCRIPTION
The choice was made here to rely on an internal NoPin implementation to hide the details
and expose it as an Alias type.

Proposal fix for #3 

It would be used like this : 
```rust
let display = DisplayNoRST::st7789_without_rst(di);
```

And it would be defined as:
```rust
  pub struct Twatch<'a> {
      pmu: Pmu<'a>,
      display: DisplayNoRST<EspSpi2InterfaceNoCS, mipidsi::models::ST7789>,
      [...]
  }
```
