### PR TITLE
keep MADCTL value to use with orientation changes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ where
     /// Sets display [Orientation]
     ///
     pub fn set_orientation(&mut self, orientation: Orientation) -> Result<(), Error<RST::Error>> {
-        let value = (self.madctl & 0b0001_1111) | (orientation as u8);
+        let value = self.madctl | ((orientation as u8) & 0b1110_0000);
         self.write_command(Instruction::MADCTL)?;
         self.write_data(&[value])?;
         self.orientation = orientation;

--- a/src/models.rs
+++ b/src/models.rs
@@ -20,15 +20,16 @@ pub trait Model {
 
     /// Initializes the display for this model
     /// and returns the value of MADCTL set by init
-    fn init<RST, DELAY>(
+    fn init<RST, DELAY, DI>(
         &mut self,
-        di: &mut dyn WriteOnlyDataCommand,
+        di: &mut DI,
         rst: &mut Option<RST>,
         delay: &mut DELAY,
     ) -> Result<u8, Error<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>;
+        DELAY: DelayUs<u32>,
+        DI: WriteOnlyDataCommand;
 
     fn hard_reset<RST, DELAY>(
         &mut self,
@@ -63,11 +64,14 @@ pub trait Model {
 }
 
 // helper for models
-pub fn write_command(
-    di: &mut dyn WriteOnlyDataCommand,
+pub fn write_command<DI>(
+    di: &mut DI,
     command: Instruction,
     params: &[u8],
-) -> Result<(), DisplayError> {
+) -> Result<(), DisplayError>
+where
+    DI: WriteOnlyDataCommand,
+{
     di.send_commands(DataFormat::U8(&[command as u8]))?;
 
     if !params.is_empty() {

--- a/src/models.rs
+++ b/src/models.rs
@@ -5,12 +5,12 @@ use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 // existing model implementations
 mod ili9486;
-mod st7789;
 mod st7735s;
+mod st7789;
 
 pub use ili9486::*;
-pub use st7789::*;
 pub use st7735s::*;
+pub use st7789::*;
 
 pub trait Model {
     type ColorFormat: RgbColor;
@@ -19,12 +19,13 @@ pub trait Model {
     fn new() -> Self;
 
     /// Initializes the display for this model
+    /// and returns the value of MADCTL set by init
     fn init<RST, DELAY>(
         &mut self,
         di: &mut dyn WriteOnlyDataCommand,
         rst: &mut Option<RST>,
         delay: &mut DELAY,
-    ) -> Result<(), Error<RST::Error>>
+    ) -> Result<u8, Error<RST::Error>>
     where
         RST: OutputPin,
         DELAY: DelayUs<u32>;

--- a/src/models/ili9486.rs
+++ b/src/models/ili9486.rs
@@ -26,15 +26,16 @@ impl Model for ILI9486Rgb565 {
         Self
     }
 
-    fn init<RST, DELAY>(
+    fn init<RST, DELAY, DI>(
         &mut self,
-        di: &mut dyn WriteOnlyDataCommand,
+        di: &mut DI,
         rst: &mut Option<RST>,
         delay: &mut DELAY,
     ) -> Result<u8, Error<RST::Error>>
     where
         RST: OutputPin,
         DELAY: DelayUs<u32>,
+        DI: WriteOnlyDataCommand,
     {
         match rst {
             Some(ref mut rst) => self.hard_reset(rst, delay)?,
@@ -69,15 +70,16 @@ impl Model for ILI9486Rgb666 {
         Self
     }
 
-    fn init<RST, DELAY>(
+    fn init<RST, DELAY, DI>(
         &mut self,
-        di: &mut dyn WriteOnlyDataCommand,
+        di: &mut DI,
         rst: &mut Option<RST>,
         delay: &mut DELAY,
     ) -> Result<u8, Error<RST::Error>>
     where
         RST: OutputPin,
         DELAY: DelayUs<u32>,
+        DI: WriteOnlyDataCommand,
     {
         match rst {
             Some(ref mut rst) => self.hard_reset(rst, delay)?,
@@ -153,12 +155,10 @@ where
 }
 
 // common init for all color format models
-fn init_common<DELAY>(
-    di: &mut dyn WriteOnlyDataCommand,
-    delay: &mut DELAY,
-) -> Result<u8, DisplayError>
+fn init_common<DELAY, DI>(di: &mut DI, delay: &mut DELAY) -> Result<u8, DisplayError>
 where
     DELAY: DelayUs<u32>,
+    DI: WriteOnlyDataCommand,
 {
     let madctl = 0b0000_0000;
 

--- a/src/models/ili9486.rs
+++ b/src/models/ili9486.rs
@@ -31,7 +31,7 @@ impl Model for ILI9486Rgb565 {
         di: &mut dyn WriteOnlyDataCommand,
         rst: &mut Option<RST>,
         delay: &mut DELAY,
-    ) -> Result<(), Error<RST::Error>>
+    ) -> Result<u8, Error<RST::Error>>
     where
         RST: OutputPin,
         DELAY: DelayUs<u32>,
@@ -74,7 +74,7 @@ impl Model for ILI9486Rgb666 {
         di: &mut dyn WriteOnlyDataCommand,
         rst: &mut Option<RST>,
         delay: &mut DELAY,
-    ) -> Result<(), Error<RST::Error>>
+    ) -> Result<u8, Error<RST::Error>>
     where
         RST: OutputPin,
         DELAY: DelayUs<u32>,
@@ -156,13 +156,15 @@ where
 fn init_common<DELAY>(
     di: &mut dyn WriteOnlyDataCommand,
     delay: &mut DELAY,
-) -> Result<(), DisplayError>
+) -> Result<u8, DisplayError>
 where
     DELAY: DelayUs<u32>,
 {
+    let madctl = 0b0000_0000;
+
     write_command(di, Instruction::SLPOUT, &[])?; // turn off sleep
     write_command(di, Instruction::COLMOD, &[0b0110_0110])?; // 18bit 256k colors
-    write_command(di, Instruction::MADCTL, &[0b0000_0000])?; // left -> right, bottom -> top RGB
+    write_command(di, Instruction::MADCTL, &[madctl])?; // left -> right, bottom -> top RGB
     write_command(di, Instruction::VCMOFSET, &[0x00, 0x48, 0x00, 0x48])?; //VCOM  Control 1 [00 40 00 40]
     write_command(di, Instruction::INVCO, &[0x0])?; //Inversion Control [00]
 
@@ -177,5 +179,5 @@ where
     // DISPON requires some time otherwise we risk SPI data issues
     delay.delay_us(120_000);
 
-    Ok(())
+    Ok(madctl)
 }

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -23,11 +23,12 @@ impl Model for ST7735s {
         di: &mut dyn WriteOnlyDataCommand,
         rst: &mut Option<RST>,
         delay: &mut DELAY,
-    ) -> Result<(), Error<RST::Error>>
+    ) -> Result<u8, Error<RST::Error>>
     where
         RST: OutputPin,
         DELAY: DelayUs<u32>,
     {
+        let madctl = 0b1010_1000;
         match rst {
             Some(ref mut rst) => self.hard_reset(rst, delay)?,
             None => write_command(di, Instruction::SWRESET, &[])?,
@@ -41,7 +42,11 @@ impl Model for ST7735s {
         write_command(di, Instruction::INVON, &[])?; // turn inversion on
         write_command(di, Instruction::FRMCTR1, &[0x05, 0x3A, 0x3A])?; // set frame rate
         write_command(di, Instruction::FRMCTR2, &[0x05, 0x3A, 0x3A])?; // set frame rate
-        write_command(di, Instruction::FRMCTR3, &[0x05, 0x3A, 0x3A, 0x05, 0x3A, 0x3A])?; // set frame rate
+        write_command(
+            di,
+            Instruction::FRMCTR3,
+            &[0x05, 0x3A, 0x3A, 0x05, 0x3A, 0x3A],
+        )?; // set frame rate
         write_command(di, Instruction::INVCO, &[0b0000_0011])?; // set inversion control
         write_command(di, Instruction::PWR1, &[0x62, 0x02, 0x04])?; // set power control 1
         write_command(di, Instruction::PWR2, &[0xC0])?; // set power control 2
@@ -49,13 +54,27 @@ impl Model for ST7735s {
         write_command(di, Instruction::PWR4, &[0x8D, 0x6A])?; // set power control 4
         write_command(di, Instruction::PWR5, &[0x8D, 0xEE])?; // set power control 5
         write_command(di, Instruction::VCMOFSET, &[0x0E])?; // set VCOM control 1
-        write_command(di, Instruction::PGC, &[0x10, 0x0E, 0x02, 0x03, 0x0E, 0x07, 0x02, 0x07, 0x0A, 0x12, 0x27, 0x37, 0x00, 0x0D, 0x0E, 0x10])?; // set GAMMA +Polarity characteristics
-        write_command(di, Instruction::NGC, &[0x10, 0x0E, 0x03, 0x03, 0x0F, 0x06, 0x02, 0x08, 0x0A, 0x13, 0x26, 0x36, 0x00, 0x0D, 0x0E, 0x10])?;  // set GAMMA -Polarity characteristics
+        write_command(
+            di,
+            Instruction::PGC,
+            &[
+                0x10, 0x0E, 0x02, 0x03, 0x0E, 0x07, 0x02, 0x07, 0x0A, 0x12, 0x27, 0x37, 0x00, 0x0D,
+                0x0E, 0x10,
+            ],
+        )?; // set GAMMA +Polarity characteristics
+        write_command(
+            di,
+            Instruction::NGC,
+            &[
+                0x10, 0x0E, 0x03, 0x03, 0x0F, 0x06, 0x02, 0x08, 0x0A, 0x13, 0x26, 0x36, 0x00, 0x0D,
+                0x0E, 0x10,
+            ],
+        )?; // set GAMMA -Polarity characteristics
         write_command(di, Instruction::COLMOD, &[0b0101_0101])?; // set interface pixel format, 16bit pixel into frame memory
-        write_command(di, Instruction::MADCTL, &[0b1010_1000])?; // set memory data access control, Top -> Bottom, RGB, Left -> Right
+        write_command(di, Instruction::MADCTL, &[madctl])?; // set memory data access control, Top -> Bottom, RGB, Left -> Right
         write_command(di, Instruction::DISPON, &[])?; // turn on display
 
-        Ok(())
+        Ok(madctl)
     }
 
     fn write_pixels<DI, I>(&mut self, di: &mut DI, colors: I) -> Result<(), DisplayError>

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -18,15 +18,16 @@ impl Model for ST7735s {
         Self
     }
 
-    fn init<RST, DELAY>(
+    fn init<RST, DELAY, DI>(
         &mut self,
-        di: &mut dyn WriteOnlyDataCommand,
+        di: &mut DI,
         rst: &mut Option<RST>,
         delay: &mut DELAY,
     ) -> Result<u8, Error<RST::Error>>
     where
         RST: OutputPin,
         DELAY: DelayUs<u32>,
+        DI: WriteOnlyDataCommand,
     {
         let madctl = 0b1010_1000;
         match rst {

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -18,15 +18,16 @@ impl Model for ST7789 {
         Self
     }
 
-    fn init<RST, DELAY>(
+    fn init<RST, DELAY, DI>(
         &mut self,
-        di: &mut dyn WriteOnlyDataCommand,
+        di: &mut DI,
         rst: &mut Option<RST>,
         delay: &mut DELAY,
     ) -> Result<u8, Error<RST::Error>>
     where
         RST: OutputPin,
         DELAY: DelayUs<u32>,
+        DI: WriteOnlyDataCommand,
     {
         let madctl = 0b0000_0000;
         match rst {

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -23,11 +23,12 @@ impl Model for ST7789 {
         di: &mut dyn WriteOnlyDataCommand,
         rst: &mut Option<RST>,
         delay: &mut DELAY,
-    ) -> Result<(), Error<RST::Error>>
+    ) -> Result<u8, Error<RST::Error>>
     where
         RST: OutputPin,
         DELAY: DelayUs<u32>,
     {
+        let madctl = 0b0000_0000;
         match rst {
             Some(ref mut rst) => self.hard_reset(rst, delay)?,
             None => write_command(di, Instruction::SWRESET, &[])?,
@@ -39,7 +40,7 @@ impl Model for ST7789 {
 
         write_command(di, Instruction::INVOFF, &[])?;
         write_command(di, Instruction::VSCRDER, &[0u8, 0u8, 0x14u8, 0u8, 0u8, 0u8])?;
-        write_command(di, Instruction::MADCTL, &[0b0000_0000])?; // left -> right, bottom -> top RGB
+        write_command(di, Instruction::MADCTL, &[madctl])?; // left -> right, bottom -> top RGB
 
         write_command(di, Instruction::COLMOD, &[0b0101_0101])?; // 16bit 65k colors
         write_command(di, Instruction::INVON, &[])?;
@@ -51,7 +52,7 @@ impl Model for ST7789 {
         // DISPON requires some time otherwise we risk SPI data issues
         delay.delay_us(120_000);
 
-        Ok(())
+        Ok(madctl)
     }
 
     fn write_pixels<DI, I>(&mut self, di: &mut DI, colors: I) -> Result<(), DisplayError>


### PR DESCRIPTION
Keeps MADCTL value from model `init` and uses it with orientation writes to keep the color and other definitions.

Should fix #7 and #8 and enable a fix for #10

I've also switched to pure static dispatch for all cases with `WriteOnlyDataCommand`