### PR TITLE
make Model size functions orientation aware

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -5,7 +5,7 @@ use embedded_graphics_core::{prelude::OriginDimensions, Pixel};
 use embedded_hal::digital::v2::OutputPin;
 
 use crate::models::Model;
-use crate::{Display, Error, Orientation};
+use crate::{Display, Error};
 use display_interface::WriteOnlyDataCommand;
 
 impl<DI, RST, M> DrawTarget for Display<DI, RST, M>
@@ -67,7 +67,7 @@ where
     }
 
     fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
-        let fb_size = self.framebuffer_size();
+        let fb_size = self.model.framebuffer_size(self.orientation);
         let fb_rect = Rectangle::with_corners(
             Point::new(0, 0),
             Point::new(fb_size.0 as i32, fb_size.1 as i32),
@@ -95,7 +95,7 @@ where
     }
 
     fn clear(&mut self, color: Self::Color) -> Result<(), Self::Error> {
-        let fb_size = self.framebuffer_size();
+        let fb_size = self.model.framebuffer_size(self.orientation);
         let pixel_count = usize::from(fb_size.0) * usize::from(fb_size.1);
         let colors = core::iter::repeat(color).take(pixel_count); // blank entire HW RAM contents
         self.set_pixels(0, 0, fb_size.0, fb_size.1, colors)
@@ -109,11 +109,8 @@ where
     MODEL: Model,
 {
     fn size(&self) -> Size {
-        let ds = self.model.display_size();
-        let (width, height) = match self.orientation {
-            Orientation::Portrait => (ds.0, ds.1),
-            Orientation::Landscape => (ds.1, ds.0),
-        };
-        Size::new(u32::from(width), u32::from(height))
+        let ds = self.model.display_size(self.orientation);
+        let (width, height) = (u32::from(ds.0), u32::from(ds.1));
+        Size::new(width, height)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,19 +251,6 @@ where
             .map_err(|_| Error::DisplayError)
     }
 
-    fn framebuffer_size(&self) -> (u16, u16)
-    where
-        DI: WriteOnlyDataCommand,
-        RST: OutputPin,
-        M: Model,
-    {
-        let ds = self.model.framebuffer_size();
-        match self.orientation {
-            Orientation::Portrait => (ds.0, ds.1),
-            Orientation::Landscape => (ds.1, ds.0),
-        }
-    }
-
     // Sets the address window for the display.
     fn set_address_window(
         &mut self,

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,4 +1,4 @@
-use crate::{instruction::Instruction, Error};
+use crate::{instruction::Instruction, Error, Orientation};
 use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
 use embedded_graphics_core::prelude::RgbColor;
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
@@ -55,11 +55,11 @@ pub trait Model {
         I: IntoIterator<Item = Self::ColorFormat>;
 
     /// Size of the visible display as `(width, height)`
-    fn display_size(&self) -> (u16, u16);
+    fn display_size(&self, orientation: Orientation) -> (u16, u16);
 
     /// Size of the display framebuffer as `(width, height)`
-    fn framebuffer_size(&self) -> (u16, u16) {
-        self.display_size()
+    fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
+        self.display_size(orientation)
     }
 }
 

--- a/src/models/ili9486.rs
+++ b/src/models/ili9486.rs
@@ -5,7 +5,7 @@ use embedded_graphics_core::{
 };
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
-use crate::{instruction::Instruction, Display, Error};
+use crate::{instruction::Instruction, Display, Error, Orientation};
 
 use super::{write_command, Model};
 
@@ -58,8 +58,11 @@ impl Model for ILI9486Rgb565 {
         di.send_data(buf)
     }
 
-    fn display_size(&self) -> (u16, u16) {
-        (320, 480)
+    fn display_size(&self, orientation: Orientation) -> (u16, u16) {
+        match orientation {
+            Orientation::Portrait => (320, 480),
+            Orientation::Landscape => (480, 320),
+        }
     }
 }
 
@@ -108,8 +111,11 @@ impl Model for ILI9486Rgb666 {
         di.send_data(buf)
     }
 
-    fn display_size(&self) -> (u16, u16) {
-        (320, 480)
+    fn display_size(&self, orientation: Orientation) -> (u16, u16) {
+        match orientation {
+            Orientation::Portrait => (320, 480),
+            Orientation::Landscape => (480, 320),
+        }
     }
 }
 

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -3,6 +3,7 @@ use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 use crate::no_pin::NoPin;
+use crate::Orientation;
 use crate::{instruction::Instruction, Display, Error};
 
 use super::{write_command, Model};
@@ -90,12 +91,18 @@ impl Model for ST7735s {
         di.send_data(buf)
     }
 
-    fn display_size(&self) -> (u16, u16) {
-        (80, 160)
+    fn display_size(&self, orientation: Orientation) -> (u16, u16) {
+        match orientation {
+            Orientation::Portrait => (80, 160),
+            Orientation::Landscape => (160, 80),
+        }
     }
 
-    fn framebuffer_size(&self) -> (u16, u16) {
-        (132, 162)
+    fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
+        match orientation {
+            Orientation::Portrait => (132, 162),
+            Orientation::Landscape => (162, 132),
+        }
     }
 }
 

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -3,6 +3,7 @@ use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 use crate::no_pin::NoPin;
+use crate::Orientation;
 use crate::{instruction::Instruction, Display, Error};
 
 use super::{write_command, Model};
@@ -68,12 +69,15 @@ impl Model for ST7789 {
         di.send_data(buf)
     }
 
-    fn display_size(&self) -> (u16, u16) {
+    fn display_size(&self, _orientation: Orientation) -> (u16, u16) {
         (240, 240)
     }
 
-    fn framebuffer_size(&self) -> (u16, u16) {
-        (240, 320)
+    fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
+        match orientation {
+            Orientation::Portrait => (240, 320),
+            Orientation::Landscape => (320, 240),
+        }
     }
 }
 


### PR DESCRIPTION
Makes `framebuffer_size` and `display_size` methods `Orientation` aware to simplify the logic.

@brianmay @KerryRJ - please review if possible, :+1: if you think it's good to go.