### PR TITLE
use DisplayOptions to allow MADCTL control, fixes #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The `Display` driver itself contains most of the functionality. Each specific di
 let di = SPIInterfaceNoCS::new(spi, dc);
 // create the ILI9486 display driver in rgb666 color mode from the display interface and RST pin
 let mut display = Display::ili9486_rgb666(di, rst);
-display.init(&mut delay::Ets)?;
+display.init(&mut delay::Ets, DisplayOptions::default())?;
 // clear the display to black
 display.clear(Rgb666::BLACK)?;
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,7 @@ where
         self.madctl = self
             .model
             .init(&mut self.di, &mut self.rst, delay_source, options)?;
+        self.orientation = options.orientation;
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,21 @@ pub enum TearingEffect {
 }
 
 ///
+/// Defines expected color component ordering, RGB or BGR
+///
+#[derive(Copy, Clone)]
+pub enum ColorOrder {
+    Rgb,
+    Bgr,
+}
+
+impl Default for ColorOrder {
+    fn default() -> Self {
+        Self::Rgb
+    }
+}
+
+///
 /// Options for displays used on initialization
 ///
 #[derive(Copy, Clone, Default)]
@@ -116,8 +131,8 @@ pub struct DisplayOptions {
     pub orientation: Orientation,
     /// Set to make display vertical refresh bottom to top
     pub invert_vertical_refresh: bool,
-    /// Set to make display use BGR instead of RGB pixel format
-    pub rgb_to_bgr: bool,
+    /// Specify display color ordering
+    pub color_order: ColorOrder,
     /// Set to make display horizontal refresh right to left
     pub invert_horizontal_refresh: bool,
 }
@@ -129,8 +144,9 @@ impl DisplayOptions {
         if self.invert_vertical_refresh {
             value |= 0b0001_0000;
         }
-        if self.rgb_to_bgr {
-            value |= 0b0000_1000;
+        match self.color_order {
+            ColorOrder::Rgb => {}
+            ColorOrder::Bgr => value |= 0b0000_1000,
         }
         if self.invert_horizontal_refresh {
             value |= 0b0000_0100;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ impl Orientation {
 
     /// Shortcut function to create un-inverted Landscape Orientation
     pub fn landscape() -> Self {
-        Self::Portrait(Inversion::None)
+        Self::Landscape(Inversion::None)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,54 +59,37 @@ where
 }
 
 ///
-/// Display orientation inversion.
-///
-#[derive(Copy, Clone)]
-pub enum Inversion {
-    None,
-    X,
-    Y,
-    XY,
-}
-
-///
 /// Display orientation.
 ///
 #[derive(Copy, Clone)]
 pub enum Orientation {
-    Portrait(Inversion),
-    Landscape(Inversion),
-}
-
-impl Orientation {
-    /// Shortcut function to create un-inverted Portrait Orientation
-    pub fn portrait() -> Self {
-        Self::Portrait(Inversion::None)
-    }
-
-    /// Shortcut function to create un-inverted Landscape Orientation
-    pub fn landscape() -> Self {
-        Self::Landscape(Inversion::None)
-    }
+    /// Portrait orientation, with mirror image parameter
+    Portrait(bool),
+    /// Landscape orientation, with mirror image parameter
+    Landscape(bool),
+    /// Inverted Portrait orientation, with mirror image parameter
+    PortraitInverted(bool),
+    /// Inverted Lanscape orientation, with mirror image parameter
+    LandscapeInverted(bool),
 }
 
 impl Default for Orientation {
     fn default() -> Self {
-        Self::Portrait(Inversion::None)
+        Self::Portrait(false)
     }
 }
 
 impl Orientation {
     pub fn value_u8(&self) -> u8 {
         match self {
-            Orientation::Portrait(Inversion::None) => 0b0000_0000,
-            Orientation::Portrait(Inversion::X) => 0b1000_0000,
-            Orientation::Portrait(Inversion::Y) => 0b0100_0000,
-            Orientation::Portrait(Inversion::XY) => 0b1100_0000,
-            Orientation::Landscape(Inversion::None) => 0b0110_0000,
-            Orientation::Landscape(Inversion::X) => 0b0010_0000,
-            Orientation::Landscape(Inversion::Y) => 0b1110_0000,
-            Orientation::Landscape(Inversion::XY) => 0b1010_0000,
+            Orientation::Portrait(false) => 0b0000_0000,
+            Orientation::Portrait(true) => 0b0100_0000,
+            Orientation::PortraitInverted(false) => 0b1100_0000,
+            Orientation::PortraitInverted(true) => 0b1000_0000,
+            Orientation::Landscape(false) => 0b0010_0000,
+            Orientation::Landscape(true) => 0b0110_0000,
+            Orientation::LandscapeInverted(false) => 0b1110_0000,
+            Orientation::LandscapeInverted(true) => 0b1010_0000,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,7 +226,7 @@ where
     /// Sets display [Orientation]
     ///
     pub fn set_orientation(&mut self, orientation: Orientation) -> Result<(), Error<RST::Error>> {
-        let value = self.madctl | (orientation.value_u8() & 0b1110_0000);
+        let value = (self.madctl & 0b0001_1111) | orientation.value_u8();
         self.write_command(Instruction::MADCTL)?;
         self.write_data(&[value])?;
         self.orientation = orientation;

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,4 +1,4 @@
-use crate::{instruction::Instruction, Error, Orientation};
+use crate::{instruction::Instruction, DisplayOptions, Error, Orientation};
 use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
 use embedded_graphics_core::prelude::RgbColor;
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
@@ -25,6 +25,7 @@ pub trait Model {
         di: &mut DI,
         rst: &mut Option<RST>,
         delay: &mut DELAY,
+        options: DisplayOptions,
     ) -> Result<u8, Error<RST::Error>>
     where
         RST: OutputPin,

--- a/src/models/ili9486.rs
+++ b/src/models/ili9486.rs
@@ -61,8 +61,8 @@ impl Model for ILI9486Rgb565 {
 
     fn display_size(&self, orientation: Orientation) -> (u16, u16) {
         match orientation {
-            Orientation::Portrait(_) => (320, 480),
-            Orientation::Landscape(_) => (480, 320),
+            Orientation::Portrait(_) | Orientation::PortraitInverted(_) => (320, 480),
+            Orientation::Landscape(_) | Orientation::LandscapeInverted(_) => (480, 320),
         }
     }
 }
@@ -115,8 +115,8 @@ impl Model for ILI9486Rgb666 {
 
     fn display_size(&self, orientation: Orientation) -> (u16, u16) {
         match orientation {
-            Orientation::Portrait(_) => (320, 480),
-            Orientation::Landscape(_) => (480, 320),
+            Orientation::Portrait(_) | Orientation::PortraitInverted(_) => (320, 480),
+            Orientation::Landscape(_) | Orientation::LandscapeInverted(_) => (480, 320),
         }
     }
 }

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -31,7 +31,8 @@ impl Model for ST7735s {
         DELAY: DelayUs<u32>,
         DI: WriteOnlyDataCommand,
     {
-        let madctl = options.madctl();
+        let madctl = options.madctl() ^ 0b0000_1000; // this model has flipped RGB/BGR bit
+
         match rst {
             Some(ref mut rst) => self.hard_reset(rst, delay)?,
             None => write_command(di, Instruction::SWRESET, &[])?,

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -3,8 +3,8 @@ use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 use crate::no_pin::NoPin;
-use crate::Orientation;
 use crate::{instruction::Instruction, Display, Error};
+use crate::{DisplayOptions, Orientation};
 
 use super::{write_command, Model};
 
@@ -24,13 +24,14 @@ impl Model for ST7735s {
         di: &mut DI,
         rst: &mut Option<RST>,
         delay: &mut DELAY,
+        options: DisplayOptions,
     ) -> Result<u8, Error<RST::Error>>
     where
         RST: OutputPin,
         DELAY: DelayUs<u32>,
         DI: WriteOnlyDataCommand,
     {
-        let madctl = 0b0000_1000;
+        let madctl = options.madctl();
         match rst {
             Some(ref mut rst) => self.hard_reset(rst, delay)?,
             None => write_command(di, Instruction::SWRESET, &[])?,
@@ -93,15 +94,15 @@ impl Model for ST7735s {
 
     fn display_size(&self, orientation: Orientation) -> (u16, u16) {
         match orientation {
-            Orientation::Portrait => (80, 160),
-            Orientation::Landscape => (160, 80),
+            Orientation::Portrait(_) => (80, 160),
+            Orientation::Landscape(_) => (160, 80),
         }
     }
 
     fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
         match orientation {
-            Orientation::Portrait => (132, 162),
-            Orientation::Landscape => (162, 132),
+            Orientation::Portrait(_) => (132, 162),
+            Orientation::Landscape(_) => (162, 132),
         }
     }
 }

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -94,15 +94,15 @@ impl Model for ST7735s {
 
     fn display_size(&self, orientation: Orientation) -> (u16, u16) {
         match orientation {
-            Orientation::Portrait(_) => (80, 160),
-            Orientation::Landscape(_) => (160, 80),
+            Orientation::Portrait(_) | Orientation::PortraitInverted(_) => (80, 160),
+            Orientation::Landscape(_) | Orientation::LandscapeInverted(_) => (160, 80),
         }
     }
 
     fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
         match orientation {
-            Orientation::Portrait(_) => (132, 162),
-            Orientation::Landscape(_) => (162, 132),
+            Orientation::Portrait(_) | Orientation::PortraitInverted(_) => (132, 162),
+            Orientation::Landscape(_) | Orientation::LandscapeInverted(_) => (162, 132),
         }
     }
 }

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -3,8 +3,8 @@ use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 use crate::no_pin::NoPin;
-use crate::Orientation;
 use crate::{instruction::Instruction, Display, Error};
+use crate::{DisplayOptions, Orientation};
 
 use super::{write_command, Model};
 
@@ -24,13 +24,14 @@ impl Model for ST7789 {
         di: &mut DI,
         rst: &mut Option<RST>,
         delay: &mut DELAY,
+        options: DisplayOptions,
     ) -> Result<u8, Error<RST::Error>>
     where
         RST: OutputPin,
         DELAY: DelayUs<u32>,
         DI: WriteOnlyDataCommand,
     {
-        let madctl = 0b0000_0000;
+        let madctl = options.madctl();
         match rst {
             Some(ref mut rst) => self.hard_reset(rst, delay)?,
             None => write_command(di, Instruction::SWRESET, &[])?,
@@ -75,8 +76,8 @@ impl Model for ST7789 {
 
     fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
         match orientation {
-            Orientation::Portrait => (240, 320),
-            Orientation::Landscape => (320, 240),
+            Orientation::Portrait(_) => (240, 320),
+            Orientation::Landscape(_) => (320, 240),
         }
     }
 }

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -76,8 +76,8 @@ impl Model for ST7789 {
 
     fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
         match orientation {
-            Orientation::Portrait(_) => (240, 320),
-            Orientation::Landscape(_) => (320, 240),
+            Orientation::Portrait(_) | Orientation::PortraitInverted(_) => (240, 320),
+            Orientation::Landscape(_) | Orientation::LandscapeInverted(_) => (320, 240),
         }
     }
 }

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -31,7 +31,7 @@ impl Model for ST7789 {
         DELAY: DelayUs<u32>,
         DI: WriteOnlyDataCommand,
     {
-        let madctl = options.madctl();
+        let madctl = options.madctl() ^ 0b0000_1000; // this model has flipped RGB/BGR bit
         match rst {
             Some(ref mut rst) => self.hard_reset(rst, delay)?,
             None => write_command(di, Instruction::SWRESET, &[])?,


### PR DESCRIPTION
Introduces `DisplayOptions` with all possible `MADCTL` values abstracted into a more digestible struct.

I've also refactored `Orientation` to include inversion logic so we don't have `init` vs `set_orientation` asymmetry.

This should fix #10