### PR TITLE
add ST7789VW waveshare model

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,8 @@ jobs:
     continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       matrix:
-        # All generated code should be running on stable now, MRSV is 1.42.0
-        rust: [nightly, stable, 1.56.0]
+        # All generated code should be running on stable now, MRSV is 1.59.0
+        rust: [nightly, stable, 1.59.0]
 
         include:
           # Nightly is only for reference and allowed to fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- added `Model::address_window_offset()` to `Model` trait
+- added `ST7789VW` waveshare model
+
 ## [v0.2.0] - 2021-04-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- bumped MSRV to 1.59
+
 ### Added
 - added `Model::address_window_offset()` to `Model` trait
 - added `ST7789VW` waveshare model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - bumped MSRV to 1.59
+- use `Default` for `Model` constructor and move `new` out of trait
 
 ### Added
 - added `Model::address_window_offset()` to `Model` trait
-- added `ST7789VW` waveshare model
+- added `ST7789VW` waveshare model with specific `new` method with window offsets
 
 ## [v0.2.0] - 2021-04-12
 

--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ License: MIT
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.56.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.59.0 and up. It *might*
 compile with older versions but that may change in any new patch release.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,12 +346,14 @@ where
         ex: u16,
         ey: u16,
     ) -> Result<(), Error<RST::Error>> {
+        let offset = self.model.address_window_offset(self.orientation);
+
         self.write_command(Instruction::CASET)?;
-        self.write_data(&sx.to_be_bytes())?;
-        self.write_data(&ex.to_be_bytes())?;
+        self.write_data(&(sx + offset.0).to_be_bytes())?;
+        self.write_data(&(ex + offset.0).to_be_bytes())?;
         self.write_command(Instruction::RASET)?;
-        self.write_data(&sy.to_be_bytes())?;
-        self.write_data(&ey.to_be_bytes())
+        self.write_data(&(sy + offset.1).to_be_bytes())?;
+        self.write_data(&(ey + offset.1).to_be_bytes())
     }
 
     ///

--- a/src/models.rs
+++ b/src/models.rs
@@ -17,9 +17,6 @@ pub use st7789vw::*;
 pub trait Model {
     type ColorFormat: RgbColor;
 
-    /// Common model constructor
-    fn new() -> Self;
-
     /// Initializes the display for this model
     /// and returns the value of MADCTL set by init
     fn init<RST, DELAY, DI>(

--- a/src/models.rs
+++ b/src/models.rs
@@ -7,10 +7,12 @@ use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 mod ili9486;
 mod st7735s;
 mod st7789;
+mod st7789vw;
 
 pub use ili9486::*;
 pub use st7735s::*;
 pub use st7789::*;
+pub use st7789vw::*;
 
 pub trait Model {
     type ColorFormat: RgbColor;
@@ -61,6 +63,12 @@ pub trait Model {
     /// Size of the display framebuffer as `(width, height)`
     fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
         self.display_size(orientation)
+    }
+
+    /// Model specific address window offset override. Used in some models
+    /// where the display is smaller than the driver draw area (e.g. Waveshare)
+    fn address_window_offset(&self, _orientation: Orientation) -> (u16, u16) {
+        (0, 0)
     }
 }
 

--- a/src/models/ili9486.rs
+++ b/src/models/ili9486.rs
@@ -12,19 +12,17 @@ use super::{write_command, Model};
 /// ILI9486 display with Reset pin
 /// in Rgb565 color mode (does *NOT* work with SPI)
 /// Backlight pin is not controlled
+#[derive(Default)]
 pub struct ILI9486Rgb565;
 
 /// ILI9486 display with Reset pin
 /// in Rgb666 color mode (works with SPI)
 /// Backlight pin is not controlled
+#[derive(Default)]
 pub struct ILI9486Rgb666;
 
 impl Model for ILI9486Rgb565 {
     type ColorFormat = Rgb565;
-
-    fn new() -> Self {
-        Self
-    }
 
     fn init<RST, DELAY, DI>(
         &mut self,
@@ -69,10 +67,6 @@ impl Model for ILI9486Rgb565 {
 
 impl Model for ILI9486Rgb666 {
     type ColorFormat = Rgb666;
-
-    fn new() -> Self {
-        Self
-    }
 
     fn init<RST, DELAY, DI>(
         &mut self,
@@ -139,7 +133,7 @@ where
     /// * `model` - the display [Model]
     ///
     pub fn ili9486_rgb565(di: DI, rst: RST) -> Self {
-        Self::with_model(di, Some(rst), ILI9486Rgb565::new())
+        Self::with_model(di, Some(rst), ILI9486Rgb565::default())
     }
 }
 
@@ -158,7 +152,7 @@ where
     /// * `model` - the display [Model]
     ///
     pub fn ili9486_rgb666(di: DI, rst: RST) -> Self {
-        Self::with_model(di, Some(rst), ILI9486Rgb666::new())
+        Self::with_model(di, Some(rst), ILI9486Rgb666::default())
     }
 }
 

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -10,14 +10,11 @@ use super::{write_command, Model};
 
 /// ST7735s SPI display with Reset pin
 /// Only SPI with DC pin interface is supported
+#[derive(Default)]
 pub struct ST7735s;
 
 impl Model for ST7735s {
     type ColorFormat = Rgb565;
-
-    fn new() -> Self {
-        Self
-    }
 
     fn init<RST, DELAY, DI>(
         &mut self,
@@ -126,7 +123,7 @@ where
     /// * `model` - the display [Model]
     ///
     pub fn st7735s(di: DI, rst: RST) -> Self {
-        Self::with_model(di, Some(rst), ST7735s::new())
+        Self::with_model(di, Some(rst), ST7735s::default())
     }
 }
 
@@ -144,6 +141,6 @@ where
     /// * `model` - the display [Model]
     ///
     pub fn st7735s_without_rst(di: DI) -> Self {
-        Self::with_model(di, None, ST7735s::new())
+        Self::with_model(di, None, ST7735s::default())
     }
 }

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -10,14 +10,11 @@ use super::{write_command, Model};
 
 /// ST7789 SPI display with Reset pin
 /// Only SPI with DC pin interface is supported
+#[derive(Default)]
 pub struct ST7789;
 
 impl Model for ST7789 {
     type ColorFormat = Rgb565;
-
-    fn new() -> Self {
-        Self
-    }
 
     fn init<RST, DELAY, DI>(
         &mut self,
@@ -100,7 +97,7 @@ where
     /// * `model` - the display [Model]
     ///
     pub fn st7789(di: DI, rst: RST) -> Self {
-        Self::with_model(di, Some(rst), ST7789::new())
+        Self::with_model(di, Some(rst), ST7789::default())
     }
 }
 
@@ -118,6 +115,6 @@ where
     /// * `model` - the display [Model]
     ///
     pub fn st7789_without_rst(di: DI) -> Self {
-        Self::with_model(di, None, ST7789::new())
+        Self::with_model(di, None, ST7789::default())
     }
 }

--- a/src/models/st7789vw.rs
+++ b/src/models/st7789vw.rs
@@ -1,0 +1,131 @@
+use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
+use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
+use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+
+use crate::no_pin::NoPin;
+use crate::{instruction::Instruction, Display, Error};
+use crate::{DisplayOptions, Orientation};
+
+use super::{write_command, Model};
+
+/// ST7789VW SPI display with Reset pin
+/// Only SPI with DC pin interface is supported
+pub struct ST7789VW;
+
+impl Model for ST7789VW {
+    type ColorFormat = Rgb565;
+
+    fn new() -> Self {
+        Self
+    }
+
+    fn init<RST, DELAY, DI>(
+        &mut self,
+        di: &mut DI,
+        rst: &mut Option<RST>,
+        delay: &mut DELAY,
+        options: DisplayOptions,
+    ) -> Result<u8, Error<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs<u32>,
+        DI: WriteOnlyDataCommand,
+    {
+        let madctl = options.madctl() ^ 0b0000_1000; // this model has flipped RGB/BGR bit
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay)?,
+            None => write_command(di, Instruction::SWRESET, &[])?,
+        }
+        delay.delay_us(150_000);
+
+        write_command(di, Instruction::SLPOUT, &[])?; // turn off sleep
+        delay.delay_us(10_000);
+
+        write_command(di, Instruction::INVOFF, &[])?;
+        write_command(di, Instruction::VSCRDER, &[0u8, 0u8, 0x14u8, 0u8, 0u8, 0u8])?;
+        write_command(di, Instruction::MADCTL, &[madctl])?; // left -> right, bottom -> top RGB
+
+        write_command(di, Instruction::COLMOD, &[0b0101_0101])?; // 16bit 65k colors
+        write_command(di, Instruction::INVON, &[])?;
+        delay.delay_us(10_000);
+        write_command(di, Instruction::NORON, &[])?; // turn to normal mode
+        delay.delay_us(10_000);
+        write_command(di, Instruction::DISPON, &[])?; // turn on display
+
+        // DISPON requires some time otherwise we risk SPI data issues
+        delay.delay_us(120_000);
+
+        Ok(madctl)
+    }
+
+    fn write_pixels<DI, I>(&mut self, di: &mut DI, colors: I) -> Result<(), DisplayError>
+    where
+        DI: WriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        write_command(di, Instruction::RAMWR, &[])?;
+        let mut iter = colors.into_iter().map(|c| c.into_storage());
+
+        let buf = DataFormat::U16BEIter(&mut iter);
+        di.send_data(buf)
+    }
+
+    fn display_size(&self, _orientation: Orientation) -> (u16, u16) {
+        (240, 135)
+    }
+
+    fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
+        match orientation {
+            Orientation::Portrait(_) | Orientation::PortraitInverted(_) => (240, 135),
+            Orientation::Landscape(_) | Orientation::LandscapeInverted(_) => (135, 240),
+        }
+    }
+
+    // Waveshare st7789vw requires an offset
+    fn address_window_offset(&self, orientation: Orientation) -> (u16, u16) {
+        match orientation {
+            Orientation::Portrait(_) | Orientation::PortraitInverted(_) => (52, 40),
+            Orientation::Landscape(_) | Orientation::LandscapeInverted(_) => (40, 53),
+        }
+    }
+}
+
+// simplified constructor on Display
+
+impl<DI, RST> Display<DI, RST, ST7789VW>
+where
+    DI: WriteOnlyDataCommand,
+    RST: OutputPin,
+{
+    ///
+    /// Creates a new [Display] instance with [ST7789VW] as the [Model] with a
+    /// hard reset Pin
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `rst` - display hard reset [OutputPin]
+    /// * `model` - the display [Model]
+    ///
+    pub fn st7789vw(di: DI, rst: RST) -> Self {
+        Self::with_model(di, Some(rst), ST7789VW::new())
+    }
+}
+
+impl<DI> Display<DI, NoPin, ST7789VW>
+where
+    DI: WriteOnlyDataCommand,
+{
+    ///
+    /// Creates a new [Display] instance with [ST7789VW] as the [Model] without
+    /// a hard reset Pin
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `model` - the display [Model]
+    ///
+    pub fn st7789vw_without_rst(di: DI) -> Self {
+        Self::with_model(di, None, ST7789VW::new())
+    }
+}

--- a/src/models/st7789vw.rs
+++ b/src/models/st7789vw.rs
@@ -10,14 +10,19 @@ use super::{write_command, Model};
 
 /// ST7789VW SPI display with Reset pin
 /// Only SPI with DC pin interface is supported
-pub struct ST7789VW;
+#[derive(Default)]
+pub struct ST7789VW {
+    window_offsets: (u16, u16),
+}
+
+impl ST7789VW {
+    pub fn new(window_offsets: (u16, u16)) -> Self {
+        Self { window_offsets }
+    }
+}
 
 impl Model for ST7789VW {
     type ColorFormat = Rgb565;
-
-    fn new() -> Self {
-        Self
-    }
 
     fn init<RST, DELAY, DI>(
         &mut self,
@@ -84,8 +89,12 @@ impl Model for ST7789VW {
     // Waveshare st7789vw requires an offset
     fn address_window_offset(&self, orientation: Orientation) -> (u16, u16) {
         match orientation {
-            Orientation::Portrait(_) | Orientation::PortraitInverted(_) => (52, 40),
-            Orientation::Landscape(_) | Orientation::LandscapeInverted(_) => (40, 53),
+            Orientation::Portrait(_) | Orientation::PortraitInverted(_) => {
+                (self.window_offsets.0, self.window_offsets.1)
+            }
+            Orientation::Landscape(_) | Orientation::LandscapeInverted(_) => {
+                (self.window_offsets.1, self.window_offsets.0)
+            }
         }
     }
 }
@@ -105,10 +114,11 @@ where
     ///
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
     /// * `rst` - display hard reset [OutputPin]
+    /// * `window_offsets` - offsets for windowing (caset/raset) for displays that need them
     /// * `model` - the display [Model]
     ///
-    pub fn st7789vw(di: DI, rst: RST) -> Self {
-        Self::with_model(di, Some(rst), ST7789VW::new())
+    pub fn st7789vw(di: DI, rst: RST, window_offsets: (u16, u16)) -> Self {
+        Self::with_model(di, Some(rst), ST7789VW::new(window_offsets))
     }
 }
 
@@ -123,9 +133,10 @@ where
     /// # Arguments
     ///
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `window_offsets` - offsets for windowing (caset/raset) for displays that need them
     /// * `model` - the display [Model]
     ///
-    pub fn st7789vw_without_rst(di: DI) -> Self {
-        Self::with_model(di, None, ST7789VW::new())
+    pub fn st7789vw_without_rst(di: DI, window_offsets: (u16, u16)) -> Self {
+        Self::with_model(di, None, ST7789VW::new(window_offsets))
     }
 }


### PR DESCRIPTION
Adds support for ST7789VW waveshare display model. Superseded #19 