### PR TITLE
Bug fixes for #23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+ - fix `Display::clear` out of bounds pixels
+ - remove `ST7789` model `Bgr` bit override
+
 ## [v0.2.1] - 2022-08-03
 
 ### Added

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -98,7 +98,7 @@ where
         let fb_size = self.model.framebuffer_size(self.orientation);
         let pixel_count = usize::from(fb_size.0) * usize::from(fb_size.1);
         let colors = core::iter::repeat(color).take(pixel_count); // blank entire HW RAM contents
-        self.set_pixels(0, 0, fb_size.0, fb_size.1, colors)
+        self.set_pixels(0, 0, fb_size.0 - 1, fb_size.1 - 1, colors)
     }
 }
 

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -31,7 +31,7 @@ impl Model for ST7789 {
         DELAY: DelayUs<u32>,
         DI: WriteOnlyDataCommand,
     {
-        let madctl = options.madctl() ^ 0b0000_1000; // this model has flipped RGB/BGR bit
+        let madctl = options.madctl();
         match rst {
             Some(ref mut rst) => self.hard_reset(rst, delay)?,
             None => write_command(di, Instruction::SWRESET, &[])?,


### PR DESCRIPTION
1. Fix `Display::clear` to `set_pixels` correctly
2. Remove bad MADCTL override for ST7789 Bgr bit

This should fix #23 