### PR TITLE
Add support for the ILI9342C

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -4,10 +4,12 @@ use embedded_graphics_core::prelude::RgbColor;
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 // existing model implementations
+mod ili9342c;
 mod ili9486;
 mod st7735s;
 mod st7789;
 
+pub use ili9342c::*;
 pub use ili9486::*;
 pub use st7735s::*;
 pub use st7789::*;

--- a/src/models/ili9342c.rs
+++ b/src/models/ili9342c.rs
@@ -1,5 +1,8 @@
 use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
-use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
+use embedded_graphics_core::{
+    pixelcolor::{Rgb565, Rgb666},
+    prelude::{IntoStorage, RgbColor},
+};
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 use crate::{instruction::Instruction, Display, DisplayOptions, Error, Orientation};
@@ -10,6 +13,11 @@ use super::{write_command, Model};
 /// in Rgb565 color mode
 /// Backlight pin is not controlled
 pub struct ILI9342CRgb565;
+
+/// ILI9342C display with Reset pin
+/// in Rgb666 color mode
+/// Backlight pin is not controlled
+pub struct ILI9342CRgb666;
 
 impl Model for ILI9342CRgb565 {
     type ColorFormat = Rgb565;
@@ -37,6 +45,8 @@ impl Model for ILI9342CRgb565 {
 
         delay.delay_us(120_000);
 
+        write_command(di, Instruction::COLMOD, &[0b0101_0101])?; // 16bit 65k colors
+
         init_common(di, delay, options).map_err(|_| Error::DisplayError)
     }
 
@@ -49,6 +59,62 @@ impl Model for ILI9342CRgb565 {
         let mut iter = colors.into_iter().map(|c| c.into_storage());
 
         let buf = DataFormat::U16BEIter(&mut iter);
+        di.send_data(buf)
+    }
+
+    fn display_size(&self, orientation: Orientation) -> (u16, u16) {
+        match orientation {
+            Orientation::Portrait(_) | Orientation::PortraitInverted(_) => (320, 240),
+            Orientation::Landscape(_) | Orientation::LandscapeInverted(_) => (240, 320),
+        }
+    }
+}
+
+impl Model for ILI9342CRgb666 {
+    type ColorFormat = Rgb666;
+
+    fn new() -> Self {
+        Self
+    }
+
+    fn init<RST, DELAY, DI>(
+        &mut self,
+        di: &mut DI,
+        rst: &mut Option<RST>,
+        delay: &mut DELAY,
+        options: DisplayOptions,
+    ) -> Result<u8, Error<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs<u32>,
+        DI: WriteOnlyDataCommand,
+    {
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay)?,
+            None => write_command(di, Instruction::SWRESET, &[])?,
+        }
+
+        delay.delay_us(120_000);
+
+        write_command(di, Instruction::COLMOD, &[0b0110_0110])?; // 18bit 262k colors
+
+        init_common(di, delay, options).map_err(|_| Error::DisplayError)
+    }
+
+    fn write_pixels<DI, I>(&mut self, di: &mut DI, colors: I) -> Result<(), DisplayError>
+    where
+        DI: WriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        write_command(di, Instruction::RAMWR, &[])?;
+        let mut iter = colors.into_iter().flat_map(|c| {
+            let red = c.r() << 2;
+            let green = c.g() << 2;
+            let blue = c.b() << 2;
+            [red, green, blue]
+        });
+
+        let buf = DataFormat::U8Iter(&mut iter);
         di.send_data(buf)
     }
 
@@ -82,6 +148,25 @@ where
     }
 }
 
+impl<DI, RST> Display<DI, RST, ILI9342CRgb666>
+where
+    DI: WriteOnlyDataCommand,
+    RST: OutputPin,
+{
+    ///
+    /// Creates a new [Display] instance with [ILI9342C] as the [Model]
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `rst` - display hard reset [OutputPin]
+    /// * `model` - the display [Model]
+    ///
+    pub fn ili9342c_rgb666(di: DI, rst: RST) -> Self {
+        Self::with_model(di, Some(rst), ILI9342CRgb666::new())
+    }
+}
+
 // common init for all color format models
 fn init_common<DELAY, DI>(
     di: &mut DI,
@@ -95,7 +180,6 @@ where
     let madctl = options.madctl() ^ 0b0000_1000; // this model has flipped RGB/BGR bit;
 
     write_command(di, Instruction::SLPOUT, &[])?; // turn off sleep
-    write_command(di, Instruction::COLMOD, &[0b0101_0101])?; // 16bit 65k colors
     write_command(di, Instruction::MADCTL, &[madctl])?; // left -> right, bottom -> top RGB
     write_command(di, Instruction::INVCO, &[0x0])?; //Inversion Control [00]
 

--- a/src/models/ili9342c.rs
+++ b/src/models/ili9342c.rs
@@ -1,0 +1,109 @@
+use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
+use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
+use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+
+use crate::{instruction::Instruction, Display, DisplayOptions, Error, Orientation};
+
+use super::{write_command, Model};
+
+/// ILI9342C display with Reset pin
+/// in Rgb565 color mode
+/// Backlight pin is not controlled
+pub struct ILI9342CRgb565;
+
+impl Model for ILI9342CRgb565 {
+    type ColorFormat = Rgb565;
+
+    fn new() -> Self {
+        Self
+    }
+
+    fn init<RST, DELAY, DI>(
+        &mut self,
+        di: &mut DI,
+        rst: &mut Option<RST>,
+        delay: &mut DELAY,
+        options: DisplayOptions,
+    ) -> Result<u8, Error<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs<u32>,
+        DI: WriteOnlyDataCommand,
+    {
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay)?,
+            None => write_command(di, Instruction::SWRESET, &[])?,
+        }
+
+        delay.delay_us(120_000);
+
+        init_common(di, delay, options).map_err(|_| Error::DisplayError)
+    }
+
+    fn write_pixels<DI, I>(&mut self, di: &mut DI, colors: I) -> Result<(), DisplayError>
+    where
+        DI: WriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        write_command(di, Instruction::RAMWR, &[])?;
+        let mut iter = colors.into_iter().map(|c| c.into_storage());
+
+        let buf = DataFormat::U16BEIter(&mut iter);
+        di.send_data(buf)
+    }
+
+    fn display_size(&self, orientation: Orientation) -> (u16, u16) {
+        match orientation {
+            Orientation::Portrait(_) | Orientation::PortraitInverted(_) => (320, 240),
+            Orientation::Landscape(_) | Orientation::LandscapeInverted(_) => (240, 320),
+        }
+    }
+}
+
+// simplified constructor for Display
+
+impl<DI, RST> Display<DI, RST, ILI9342CRgb565>
+where
+    DI: WriteOnlyDataCommand,
+    RST: OutputPin,
+{
+    ///
+    /// Creates a new [Display] instance with [ILI9342C] as the [Model]
+    /// *WARNING* Rgb565 only works on non-SPI setups with the ILI9342C!
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `rst` - display hard reset [OutputPin]
+    /// * `model` - the display [Model]
+    ///
+    pub fn ili9342c_rgb565(di: DI, rst: RST) -> Self {
+        Self::with_model(di, Some(rst), ILI9342CRgb565::new())
+    }
+}
+
+// common init for all color format models
+fn init_common<DELAY, DI>(
+    di: &mut DI,
+    delay: &mut DELAY,
+    options: DisplayOptions,
+) -> Result<u8, DisplayError>
+where
+    DELAY: DelayUs<u32>,
+    DI: WriteOnlyDataCommand,
+{
+    let madctl = options.madctl() ^ 0b0000_1000; // this model has flipped RGB/BGR bit;
+
+    write_command(di, Instruction::SLPOUT, &[])?; // turn off sleep
+    write_command(di, Instruction::COLMOD, &[0b0101_0101])?; // 16bit 65k colors
+    write_command(di, Instruction::MADCTL, &[madctl])?; // left -> right, bottom -> top RGB
+    write_command(di, Instruction::INVCO, &[0x0])?; //Inversion Control [00]
+
+    write_command(di, Instruction::NORON, &[])?; // turn to normal mode
+    write_command(di, Instruction::DISPON, &[])?; // turn on display
+
+    // DISPON requires some time otherwise we risk SPI data issues
+    delay.delay_us(120_000);
+
+    Ok(madctl)
+}


### PR DESCRIPTION
First off, thank you for your work on this project! I had previously attempted to implement this driver from scratch and lost motivation, however it was trivial to implement in this repository.

The [ILI9342C](https://focuslcds.com/content/ILI9342C.pdf) is used by the [ESP32-S3-BOX](https://github.com/espressif/esp-box), which is what I used for verification. Based on some very simple testing this seems to be working as intended.

Some notes on this implementation:

- Very similar to the current `ili9486` model, with some small tweaks
- I've based the initialization routine on [this driver](https://github.com/russhughes/ili9342c_mpy); I'm not certain if everything has been covered, but it is funcional
- Currently only supports `Rgb565`; I did try `Rgb666` however the colours were not correct, and I did not spend much time trying to troubleshoot
- For whatever reason the width/height values needed to be the reverse of what I'd normally expect (smaller then larger), however this seems to be how this display works

If you'd like anything changed or added please let me know!