### PR TITLE
Refactors the driver and models to support dynamic display sizing and clipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- split [DisplayOptions] into [DisplayOptions] and [ModelOptions] with sizing initialization safety constructors
 - refactored `Display::init` and constructors to match new variant code
 - fixed off by one error in fill operations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- support for model variants via `DisplayOptions`
+- support for `raspberry pico1` variant of the `ST7789` display
+- support for the `waveshare` variants of the `ST7789` display
+
+### Changed
+
+- refactored `Display::init` and constructors to match new variant code
+- fixed off by one error in fill operations
+
+### Removed
+
+- removed "no reset pin" constructor helpers (uses `Option` now)
+
 ## [v0.3.0] - 2022-08-30
 
 ### Added

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -70,7 +70,7 @@ where
         let fb_size = self.model.options().framebuffer_size(self.orientation);
         let fb_rect = Rectangle::with_corners(
             Point::new(0, 0),
-            Point::new(fb_size.0 as i32, fb_size.1 as i32),
+            Point::new(fb_size.0 as i32 - 1, fb_size.1 as i32 - 1),
         );
         let area = area.intersection(&fb_rect);
 

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -67,7 +67,7 @@ where
     }
 
     fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
-        let fb_size = self.model.framebuffer_size(self.orientation);
+        let fb_size = self.model.options().framebuffer_size(self.orientation);
         let fb_rect = Rectangle::with_corners(
             Point::new(0, 0),
             Point::new(fb_size.0 as i32, fb_size.1 as i32),
@@ -95,7 +95,7 @@ where
     }
 
     fn clear(&mut self, color: Self::Color) -> Result<(), Self::Error> {
-        let fb_size = self.model.framebuffer_size(self.orientation);
+        let fb_size = self.model.options().framebuffer_size(self.orientation);
         let pixel_count = usize::from(fb_size.0) * usize::from(fb_size.1);
         let colors = core::iter::repeat(color).take(pixel_count); // blank entire HW RAM contents
         self.set_pixels(0, 0, fb_size.0 - 1, fb_size.1 - 1, colors)
@@ -109,7 +109,7 @@ where
     MODEL: Model,
 {
     fn size(&self) -> Size {
-        let ds = self.model.display_size(self.orientation);
+        let ds = self.model.options().display_size(self.orientation);
         let (width, height) = (u32::from(ds.0), u32::from(ds.1));
         Size::new(width, height)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub struct DisplayOptions {
     /// Set to make display horizontal refresh right to left
     pub invert_horizontal_refresh: bool,
     /// Offsets (x, y) for windowing in physically cropped displays (e.g. Pico v1)
-    pub offset: (u16, u16),
+    pub window_offset: (u16, u16),
     /// Display size (w, h) override for the display/model, (0, 0) for no override
     pub display_size: (u16, u16),
     /// Framebuffer size (w, h) override for the display/model, (0, 0) for no override
@@ -162,36 +162,43 @@ impl DisplayOptions {
     }
 
     ///
+    /// Sets the display size value if not set previously yet and returns the
+    /// same [DisplayOptions] object back
+    ///
+    pub fn with_display_size(mut self, width: u16, height: u16) -> Self {
+        if self.display_size == (0, 0) {
+            self.display_size = (width, height);
+        }
+
+        self
+    }
+
+    ///
+    /// Sets the display and frame buffer size values if not set previously yet
+    /// and returns the same [DisplayOptions] object back
+    ///
+    pub fn with_sizes(mut self, display_size: (u16, u16), framebuffer_size: (u16, u16)) -> Self {
+        if self.framebuffer_size == (0, 0) {
+            self.framebuffer_size = framebuffer_size;
+        }
+
+        self.with_display_size(display_size.0, display_size.1)
+    }
+
+    ///
     /// Returns display size based on current orientation and display options.
     /// Used by models.
     ///
-    pub fn display_size(&self, width: u16, height: u16, orientation: Orientation) -> (u16, u16) {
-        let size = if self.display_size == (0, 0) {
-            (width, height)
-        } else {
-            self.display_size
-        };
-
-        Self::orient_size(size, orientation)
+    pub fn display_size(&self, orientation: Orientation) -> (u16, u16) {
+        Self::orient_size(self.display_size, orientation)
     }
 
     ///
     /// Returns framebuffer size based on current orientation and display options.
     /// Used by models.
     ///
-    pub fn framebuffer_size(
-        &self,
-        width: u16,
-        height: u16,
-        orientation: Orientation,
-    ) -> (u16, u16) {
-        let size = if self.framebuffer_size == (0, 0) {
-            (width, height)
-        } else {
-            self.framebuffer_size
-        };
-
-        Self::orient_size(size, orientation)
+    pub fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
+        Self::orient_size(self.framebuffer_size, orientation)
     }
 
     // Flip size according to orientation, in general

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,10 @@ pub struct DisplayOptions {
     pub color_order: ColorOrder,
     /// Set to make display horizontal refresh right to left
     pub invert_horizontal_refresh: bool,
+    /// Offsets (x, y) for windowing in physically cropped displays (e.g. Pico v1)
+    pub offset: (u16, u16),
+    /// Display size (w, h) for the display
+    pub size: (u16, u16)    
 }
 
 impl DisplayOptions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,10 +214,16 @@ impl DisplayOptions {
 
     ///
     /// Returns framebuffer size based on current orientation and display options.
-    /// Used by models.
+    /// Used by models. Uses display_size if framebuffer_size is not set.
     ///
     pub fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
-        Self::orient_size(self.framebuffer_size, orientation)
+        let size = if self.framebuffer_size == (0, 0) {
+            self.display_size
+        } else {
+            self.framebuffer_size
+        };
+
+        Self::orient_size(size, orientation)
     }
 
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,6 +395,10 @@ where
         ex: u16,
         ey: u16,
     ) -> Result<(), Error<RST::Error>> {
+        // add clipping offsets if present
+        let offset = self.model.options().window_offset;
+        let (sx, sy, ex, ey) = (sx + offset.0, sy + offset.1, ex + offset.0, ey + offset.1);
+
         self.write_command(Instruction::CASET)?;
         self.write_data(&sx.to_be_bytes())?;
         self.write_data(&ex.to_be_bytes())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,14 @@ impl DisplayOptions {
         Self::orient_size(self.framebuffer_size, orientation)
     }
 
+    ///
+    /// Returns window offset based on current orientation and display options.
+    /// Used by [Display::set_address_window]
+    ///
+    pub fn window_offset(&self, orientation: Orientation) -> (u16, u16) {
+        Self::orient_size(self.window_offset, orientation)
+    }
+
     // Flip size according to orientation, in general
     fn orient_size(size: (u16, u16), orientation: Orientation) -> (u16, u16) {
         match orientation {
@@ -396,7 +404,7 @@ where
         ey: u16,
     ) -> Result<(), Error<RST::Error>> {
         // add clipping offsets if present
-        let offset = self.model.options().window_offset;
+        let offset = self.model.options().window_offset(self.orientation);
         let (sx, sy, ex, ey) = (sx + offset.0, sy + offset.1, ex + offset.0, ey + offset.1);
 
         self.write_command(Instruction::CASET)?;

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,4 +1,4 @@
-use crate::{instruction::Instruction, DisplayOptions, Error, Orientation};
+use crate::{instruction::Instruction, DisplayOptions, Error};
 use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
 use embedded_graphics_core::prelude::RgbColor;
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
@@ -55,14 +55,6 @@ pub trait Model {
     where
         DI: WriteOnlyDataCommand,
         I: IntoIterator<Item = Self::ColorFormat>;
-
-    /// Size of the visible display as `(width, height)`
-    fn display_size(&self, orientation: Orientation) -> (u16, u16);
-
-    /// Size of the display framebuffer as `(width, height)`
-    fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
-        self.display_size(orientation)
-    }
 
     fn options(&self) -> &DisplayOptions;
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,4 +1,4 @@
-use crate::{instruction::Instruction, DisplayOptions, Error};
+use crate::{instruction::Instruction, ColorOrder, DisplayOptions, Error, Orientation};
 use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
 use embedded_graphics_core::prelude::RgbColor;
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
@@ -14,11 +14,149 @@ pub use ili9486::*;
 pub use st7735s::*;
 pub use st7789::*;
 
+///
+/// [DisplayOptions] that have been initialized with at minimum `display_size`
+/// values. This protects against initializing a model with 0 size.
+/// This structure also holds possible windowing offset values in case of
+/// clipped displays such as the `Pico1`
+///
+#[derive(Debug, Clone)]
+pub struct ModelOptions {
+    /// Display options
+    display_options: DisplayOptions,
+    /// Offset override function returning (w, h) offset for current
+    /// display orientation if display is "clipped" and needs an offset for (e.g. Pico v1)
+    window_offset_handler: fn(Orientation) -> (u16, u16),
+    /// Display size (w, h) override for the display/model, (0, 0) for no override
+    display_size: (u16, u16),
+    /// Framebuffer size (w, h) override for the display/model, (0, 0) for no override
+    framebuffer_size: (u16, u16),
+}
+
+fn no_offset(_: Orientation) -> (u16, u16) {
+    (0, 0)
+}
+
+impl ModelOptions {
+    ///
+    /// Constructs a [ModelOptions] from [DisplayOptions]
+    /// with given display size
+    ///
+    pub fn with_display_size(
+        display_options: DisplayOptions,
+        width: u16,
+        height: u16,
+    ) -> ModelOptions {
+        ModelOptions {
+            display_options,
+            window_offset_handler: no_offset,
+            display_size: (width, height),
+            framebuffer_size: (0, 0),
+        }
+    }
+
+    ///
+    /// Constructs a [ModelOptions] from [DisplayOptions]
+    /// with given display and framebuffer sizes
+    ///
+    pub fn with_sizes(
+        display_options: DisplayOptions,
+        display_size: (u16, u16),
+        framebuffer_size: (u16, u16),
+    ) -> ModelOptions {
+        ModelOptions {
+            display_options,
+            window_offset_handler: no_offset,
+            display_size,
+            framebuffer_size,
+        }
+    }
+
+    ///
+    /// Constructs a [ModelOptions] from [DisplayOptions]
+    /// with given display and framebuffer sizes and provided window offset handler
+    ///
+    pub fn with_all(
+        display_options: DisplayOptions,
+        display_size: (u16, u16),
+        framebuffer_size: (u16, u16),
+        window_offset_handler: fn(Orientation) -> (u16, u16),
+    ) -> ModelOptions {
+        ModelOptions {
+            display_options,
+            window_offset_handler,
+            display_size,
+            framebuffer_size,
+        }
+    }
+
+    ///
+    /// Returns MADCTL register value for given display options
+    ///
+    pub fn madctl(&self) -> u8 {
+        let mut value = self.display_options.orientation.value_u8();
+        if self.display_options.invert_vertical_refresh {
+            value |= 0b0001_0000;
+        }
+        match self.display_options.color_order {
+            ColorOrder::Rgb => {}
+            ColorOrder::Bgr => value |= 0b0000_1000,
+        }
+        if self.display_options.invert_horizontal_refresh {
+            value |= 0b0000_0100;
+        }
+
+        value
+    }
+
+    ///
+    /// Returns display size based on current orientation and display options.
+    /// Used by models.
+    ///
+    pub fn display_size(&self, orientation: Orientation) -> (u16, u16) {
+        Self::orient_size(self.display_size, orientation)
+    }
+
+    ///
+    /// Returns framebuffer size based on current orientation and display options.
+    /// Used by models. Uses display_size if framebuffer_size is not set.
+    ///
+    pub fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
+        let size = if self.framebuffer_size == (0, 0) {
+            self.display_size
+        } else {
+            self.framebuffer_size
+        };
+
+        Self::orient_size(size, orientation)
+    }
+
+    ///
+    /// Returns window offset based on current orientation and display options.
+    /// Used by [Display::set_address_window]
+    ///
+    pub fn window_offset(&self, orientation: Orientation) -> (u16, u16) {
+        (self.window_offset_handler)(orientation)
+    }
+
+    pub fn orientation(&self) -> Orientation {
+        self.display_options.orientation
+    }
+
+    // Flip size according to orientation, in general
+    fn orient_size(size: (u16, u16), orientation: Orientation) -> (u16, u16) {
+        match orientation {
+            Orientation::Portrait(_) | Orientation::PortraitInverted(_) => size,
+            Orientation::Landscape(_) | Orientation::LandscapeInverted(_) => (size.1, size.0),
+        }
+    }
+}
+
 pub trait Model {
     type ColorFormat: RgbColor;
 
     /// Common model constructor
-    fn new(options: DisplayOptions) -> Self;
+    fn new(options: ModelOptions) -> Self;
 
     /// Initializes the display for this model
     /// and returns the value of MADCTL set by init
@@ -56,7 +194,7 @@ pub trait Model {
         DI: WriteOnlyDataCommand,
         I: IntoIterator<Item = Self::ColorFormat>;
 
-    fn options(&self) -> &DisplayOptions;
+    fn options(&self) -> &ModelOptions;
 }
 
 // helper for models

--- a/src/models.rs
+++ b/src/models.rs
@@ -18,7 +18,7 @@ pub trait Model {
     type ColorFormat: RgbColor;
 
     /// Common model constructor
-    fn new() -> Self;
+    fn new(options: DisplayOptions) -> Self;
 
     /// Initializes the display for this model
     /// and returns the value of MADCTL set by init
@@ -27,7 +27,6 @@ pub trait Model {
         di: &mut DI,
         rst: &mut Option<RST>,
         delay: &mut DELAY,
-        options: DisplayOptions,
     ) -> Result<u8, Error<RST::Error>>
     where
         RST: OutputPin,
@@ -64,6 +63,8 @@ pub trait Model {
     fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
         self.display_size(orientation)
     }
+
+    fn options(&self) -> &DisplayOptions;
 }
 
 // helper for models

--- a/src/models/ili9342c.rs
+++ b/src/models/ili9342c.rs
@@ -7,23 +7,23 @@ use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 use crate::{instruction::Instruction, Display, DisplayOptions, Error};
 
-use super::{write_command, Model};
+use super::{write_command, Model, ModelOptions};
 
 /// ILI9342C display with Reset pin
 /// in Rgb565 color mode
 /// Backlight pin is not controlled
-pub struct ILI9342CRgb565(DisplayOptions);
+pub struct ILI9342CRgb565(ModelOptions);
 
 /// ILI9342C display with Reset pin
 /// in Rgb666 color mode
 /// Backlight pin is not controlled
-pub struct ILI9342CRgb666(DisplayOptions);
+pub struct ILI9342CRgb666(ModelOptions);
 
 impl Model for ILI9342CRgb565 {
     type ColorFormat = Rgb565;
 
-    fn new(options: DisplayOptions) -> Self {
-        Self(options.with_display_size(320, 240))
+    fn new(options: ModelOptions) -> Self {
+        Self(options)
     }
 
     fn init<RST, DELAY, DI>(
@@ -65,7 +65,7 @@ impl Model for ILI9342CRgb565 {
     //     self.0.display_size(320, 240, orientation)
     // }
 
-    fn options(&self) -> &DisplayOptions {
+    fn options(&self) -> &ModelOptions {
         &self.0
     }
 }
@@ -73,8 +73,8 @@ impl Model for ILI9342CRgb565 {
 impl Model for ILI9342CRgb666 {
     type ColorFormat = Rgb666;
 
-    fn new(options: DisplayOptions) -> Self {
-        Self(options.with_display_size(320, 240))
+    fn new(options: ModelOptions) -> Self {
+        Self(options)
     }
 
     fn init<RST, DELAY, DI>(
@@ -124,7 +124,7 @@ impl Model for ILI9342CRgb666 {
     //     }
     // }
 
-    fn options(&self) -> &DisplayOptions {
+    fn options(&self) -> &ModelOptions {
         &self.0
     }
 }
@@ -147,7 +147,11 @@ where
     /// * `options` - the [DisplayOptions] for this display/model
     ///
     pub fn ili9342c_rgb565(di: DI, rst: Option<RST>, options: DisplayOptions) -> Self {
-        Self::with_model(di, rst, ILI9342CRgb565::new(options))
+        Self::with_model(
+            di,
+            rst,
+            ILI9342CRgb565::new(ModelOptions::with_display_size(options, 320, 240)),
+        )
     }
 }
 
@@ -166,7 +170,11 @@ where
     /// * `options` - the [DisplayOptions] for this display/model
     ///
     pub fn ili9342c_rgb666(di: DI, rst: Option<RST>, options: DisplayOptions) -> Self {
-        Self::with_model(di, rst, ILI9342CRgb666::new(options))
+        Self::with_model(
+            di,
+            rst,
+            ILI9342CRgb666::new(ModelOptions::with_display_size(options, 320, 240)),
+        )
     }
 }
 
@@ -174,7 +182,7 @@ where
 fn init_common<DELAY, DI>(
     di: &mut DI,
     delay: &mut DELAY,
-    options: &DisplayOptions,
+    options: &ModelOptions,
 ) -> Result<u8, DisplayError>
 where
     DELAY: DelayUs<u32>,

--- a/src/models/ili9342c.rs
+++ b/src/models/ili9342c.rs
@@ -146,8 +146,8 @@ where
     /// * `rst` - display hard reset [OutputPin]
     /// * `options` - the [DisplayOptions] for this display/model
     ///
-    pub fn ili9342c_rgb565(di: DI, rst: RST, options: DisplayOptions) -> Self {
-        Self::with_model(di, Some(rst), ILI9342CRgb565::new(options))
+    pub fn ili9342c_rgb565(di: DI, rst: Option<RST>, options: DisplayOptions) -> Self {
+        Self::with_model(di, rst, ILI9342CRgb565::new(options))
     }
 }
 
@@ -165,8 +165,8 @@ where
     /// * `rst` - display hard reset [OutputPin]
     /// * `options` - the [DisplayOptions] for this display/model
     ///
-    pub fn ili9342c_rgb666(di: DI, rst: RST, options: DisplayOptions) -> Self {
-        Self::with_model(di, Some(rst), ILI9342CRgb666::new(options))
+    pub fn ili9342c_rgb666(di: DI, rst: Option<RST>, options: DisplayOptions) -> Self {
+        Self::with_model(di, rst, ILI9342CRgb666::new(options))
     }
 }
 

--- a/src/models/ili9342c.rs
+++ b/src/models/ili9342c.rs
@@ -5,7 +5,7 @@ use embedded_graphics_core::{
 };
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
-use crate::{instruction::Instruction, Display, DisplayOptions, Error, Orientation};
+use crate::{instruction::Instruction, Display, DisplayOptions, Error};
 
 use super::{write_command, Model};
 
@@ -23,7 +23,7 @@ impl Model for ILI9342CRgb565 {
     type ColorFormat = Rgb565;
 
     fn new(options: DisplayOptions) -> Self {
-        Self(options)
+        Self(options.with_display_size(320, 240))
     }
 
     fn init<RST, DELAY, DI>(
@@ -61,9 +61,9 @@ impl Model for ILI9342CRgb565 {
         di.send_data(buf)
     }
 
-    fn display_size(&self, orientation: Orientation) -> (u16, u16) {
-        self.0.display_size(320, 240, orientation)
-    }
+    // fn display_size(&self, orientation: Orientation) -> (u16, u16) {
+    //     self.0.display_size(320, 240, orientation)
+    // }
 
     fn options(&self) -> &DisplayOptions {
         &self.0
@@ -74,7 +74,7 @@ impl Model for ILI9342CRgb666 {
     type ColorFormat = Rgb666;
 
     fn new(options: DisplayOptions) -> Self {
-        Self(options)
+        Self(options.with_display_size(320, 240))
     }
 
     fn init<RST, DELAY, DI>(
@@ -117,12 +117,12 @@ impl Model for ILI9342CRgb666 {
         di.send_data(buf)
     }
 
-    fn display_size(&self, orientation: Orientation) -> (u16, u16) {
-        match orientation {
-            Orientation::Portrait(_) | Orientation::PortraitInverted(_) => (320, 240),
-            Orientation::Landscape(_) | Orientation::LandscapeInverted(_) => (240, 320),
-        }
-    }
+    // fn display_size(&self, orientation: Orientation) -> (u16, u16) {
+    //     match orientation {
+    //         Orientation::Portrait(_) | Orientation::PortraitInverted(_) => (320, 240),
+    //         Orientation::Landscape(_) | Orientation::LandscapeInverted(_) => (240, 320),
+    //     }
+    // }
 
     fn options(&self) -> &DisplayOptions {
         &self.0

--- a/src/models/ili9342c.rs
+++ b/src/models/ili9342c.rs
@@ -144,7 +144,7 @@ where
     ///
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
     /// * `rst` - display hard reset [OutputPin]
-    /// * `model` - the display [Model]
+    /// * `options` - the [DisplayOptions] for this display/model
     ///
     pub fn ili9342c_rgb565(di: DI, rst: RST, options: DisplayOptions) -> Self {
         Self::with_model(di, Some(rst), ILI9342CRgb565::new(options))
@@ -163,7 +163,6 @@ where
     ///
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
     /// * `rst` - display hard reset [OutputPin]
-    /// * `model` - the display [Model]
     /// * `options` - the [DisplayOptions] for this display/model
     ///
     pub fn ili9342c_rgb666(di: DI, rst: RST, options: DisplayOptions) -> Self {

--- a/src/models/ili9486.rs
+++ b/src/models/ili9486.rs
@@ -138,8 +138,8 @@ where
     /// * `rst` - display hard reset [OutputPin]
     /// * `options` - the [DisplayOptions] for this display/model
     ///
-    pub fn ili9486_rgb565(di: DI, rst: RST, options: DisplayOptions) -> Self {
-        Self::with_model(di, Some(rst), ILI9486Rgb565::new(options))
+    pub fn ili9486_rgb565(di: DI, rst: Option<RST>, options: DisplayOptions) -> Self {
+        Self::with_model(di, rst, ILI9486Rgb565::new(options))
     }
 }
 
@@ -157,8 +157,8 @@ where
     /// * `rst` - display hard reset [OutputPin]
     /// * `options` - the [DisplayOptions] for this display/model
     ///
-    pub fn ili9486_rgb666(di: DI, rst: RST, options: DisplayOptions) -> Self {
-        Self::with_model(di, Some(rst), ILI9486Rgb666::new(options))
+    pub fn ili9486_rgb666(di: DI, rst: Option<RST>, options: DisplayOptions) -> Self {
+        Self::with_model(di, rst, ILI9486Rgb666::new(options))
     }
 }
 

--- a/src/models/ili9486.rs
+++ b/src/models/ili9486.rs
@@ -136,7 +136,6 @@ where
     ///
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
     /// * `rst` - display hard reset [OutputPin]
-    /// * `model` - the display [Model]
     /// * `options` - the [DisplayOptions] for this display/model
     ///
     pub fn ili9486_rgb565(di: DI, rst: RST, options: DisplayOptions) -> Self {
@@ -156,7 +155,6 @@ where
     ///
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
     /// * `rst` - display hard reset [OutputPin]
-    /// * `model` - the display [Model]
     /// * `options` - the [DisplayOptions] for this display/model
     ///
     pub fn ili9486_rgb666(di: DI, rst: RST, options: DisplayOptions) -> Self {

--- a/src/models/ili9486.rs
+++ b/src/models/ili9486.rs
@@ -7,23 +7,23 @@ use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 use crate::{instruction::Instruction, Display, DisplayOptions, Error};
 
-use super::{write_command, Model};
+use super::{write_command, Model, ModelOptions};
 
 /// ILI9486 display with Reset pin
 /// in Rgb565 color mode (does *NOT* work with SPI)
 /// Backlight pin is not controlled
-pub struct ILI9486Rgb565(DisplayOptions);
+pub struct ILI9486Rgb565(ModelOptions);
 
 /// ILI9486 display with Reset pin
 /// in Rgb666 color mode (works with SPI)
 /// Backlight pin is not controlled
-pub struct ILI9486Rgb666(DisplayOptions);
+pub struct ILI9486Rgb666(ModelOptions);
 
 impl Model for ILI9486Rgb565 {
     type ColorFormat = Rgb565;
 
-    fn new(options: DisplayOptions) -> Self {
-        Self(options.with_display_size(320, 480))
+    fn new(options: ModelOptions) -> Self {
+        Self(options)
     }
 
     fn init<RST, DELAY, DI>(
@@ -62,7 +62,7 @@ impl Model for ILI9486Rgb565 {
     //     self.0.display_size(320, 480, orientation)
     // }
 
-    fn options(&self) -> &DisplayOptions {
+    fn options(&self) -> &ModelOptions {
         &self.0
     }
 }
@@ -70,7 +70,7 @@ impl Model for ILI9486Rgb565 {
 impl Model for ILI9486Rgb666 {
     type ColorFormat = Rgb666;
 
-    fn new(options: DisplayOptions) -> Self {
+    fn new(options: ModelOptions) -> Self {
         Self(options)
     }
 
@@ -116,7 +116,7 @@ impl Model for ILI9486Rgb666 {
     //     self.0.display_size(320, 480, orientation)
     // }
 
-    fn options(&self) -> &DisplayOptions {
+    fn options(&self) -> &ModelOptions {
         &self.0
     }
 }
@@ -138,7 +138,7 @@ where
     /// * `rst` - display hard reset [OutputPin]
     /// * `options` - the [DisplayOptions] for this display/model
     ///
-    pub fn ili9486_rgb565(di: DI, rst: Option<RST>, options: DisplayOptions) -> Self {
+    pub fn ili9486_rgb565(di: DI, rst: Option<RST>, options: ModelOptions) -> Self {
         Self::with_model(di, rst, ILI9486Rgb565::new(options))
     }
 }
@@ -158,7 +158,11 @@ where
     /// * `options` - the [DisplayOptions] for this display/model
     ///
     pub fn ili9486_rgb666(di: DI, rst: Option<RST>, options: DisplayOptions) -> Self {
-        Self::with_model(di, rst, ILI9486Rgb666::new(options))
+        Self::with_model(
+            di,
+            rst,
+            ILI9486Rgb666::new(ModelOptions::with_display_size(options, 320, 480)),
+        )
     }
 }
 
@@ -166,7 +170,7 @@ where
 fn init_common<DELAY, DI>(
     di: &mut DI,
     delay: &mut DELAY,
-    options: &DisplayOptions,
+    options: &ModelOptions,
 ) -> Result<u8, DisplayError>
 where
     DELAY: DelayUs<u32>,

--- a/src/models/ili9486.rs
+++ b/src/models/ili9486.rs
@@ -5,7 +5,7 @@ use embedded_graphics_core::{
 };
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
-use crate::{instruction::Instruction, Display, DisplayOptions, Error, Orientation};
+use crate::{instruction::Instruction, Display, DisplayOptions, Error};
 
 use super::{write_command, Model};
 
@@ -23,7 +23,7 @@ impl Model for ILI9486Rgb565 {
     type ColorFormat = Rgb565;
 
     fn new(options: DisplayOptions) -> Self {
-        Self(options)
+        Self(options.with_display_size(320, 480))
     }
 
     fn init<RST, DELAY, DI>(
@@ -58,9 +58,9 @@ impl Model for ILI9486Rgb565 {
         di.send_data(buf)
     }
 
-    fn display_size(&self, orientation: Orientation) -> (u16, u16) {
-        self.0.display_size(320, 480, orientation)
-    }
+    // fn display_size(&self, orientation: Orientation) -> (u16, u16) {
+    //     self.0.display_size(320, 480, orientation)
+    // }
 
     fn options(&self) -> &DisplayOptions {
         &self.0
@@ -112,9 +112,9 @@ impl Model for ILI9486Rgb666 {
         di.send_data(buf)
     }
 
-    fn display_size(&self, orientation: Orientation) -> (u16, u16) {
-        self.0.display_size(320, 480, orientation)
-    }
+    // fn display_size(&self, orientation: Orientation) -> (u16, u16) {
+    //     self.0.display_size(320, 480, orientation)
+    // }
 
     fn options(&self) -> &DisplayOptions {
         &self.0

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -2,20 +2,19 @@ use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
 use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
-use crate::DisplayOptions;
-use crate::{instruction::Instruction, Display, Error};
+use crate::{instruction::Instruction, Display, DisplayOptions, Error};
 
-use super::{write_command, Model};
+use super::{write_command, Model, ModelOptions};
 
 /// ST7735s SPI display with Reset pin
 /// Only SPI with DC pin interface is supported
-pub struct ST7735s(DisplayOptions);
+pub struct ST7735s(ModelOptions);
 
 impl Model for ST7735s {
     type ColorFormat = Rgb565;
 
-    fn new(options: DisplayOptions) -> Self {
-        Self(options.with_sizes((80, 160), (132, 162)))
+    fn new(options: ModelOptions) -> Self {
+        Self(options)
     }
 
     fn init<RST, DELAY, DI>(
@@ -99,7 +98,7 @@ impl Model for ST7735s {
     //     self.0.framebuffer_size(132, 162, orientation)
     // }
 
-    fn options(&self) -> &DisplayOptions {
+    fn options(&self) -> &ModelOptions {
         &self.0
     }
 }
@@ -122,6 +121,10 @@ where
     /// * `options` - the [DisplayOptions] for this display/model
     ///
     pub fn st7735s(di: DI, rst: Option<RST>, options: DisplayOptions) -> Self {
-        Self::with_model(di, rst, ST7735s::new(options))
+        Self::with_model(
+            di,
+            rst,
+            ST7735s::new(ModelOptions::with_sizes(options, (80, 160), (132, 162))),
+        )
     }
 }

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -3,8 +3,8 @@ use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 use crate::no_pin::NoPin;
+use crate::DisplayOptions;
 use crate::{instruction::Instruction, Display, Error};
-use crate::{DisplayOptions, Orientation};
 
 use super::{write_command, Model};
 
@@ -16,7 +16,7 @@ impl Model for ST7735s {
     type ColorFormat = Rgb565;
 
     fn new(options: DisplayOptions) -> Self {
-        Self(options)
+        Self(options.with_sizes((80, 160), (132, 162)))
     }
 
     fn init<RST, DELAY, DI>(
@@ -92,13 +92,13 @@ impl Model for ST7735s {
         di.send_data(buf)
     }
 
-    fn display_size(&self, orientation: Orientation) -> (u16, u16) {
-        self.0.display_size(80, 160, orientation)
-    }
+    // fn display_size(&self, orientation: Orientation) -> (u16, u16) {
+    //     self.0.display_size(80, 160, orientation)
+    // }
 
-    fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
-        self.0.framebuffer_size(132, 162, orientation)
-    }
+    // fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
+    //     self.0.framebuffer_size(132, 162, orientation)
+    // }
 
     fn options(&self) -> &DisplayOptions {
         &self.0

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -10,13 +10,13 @@ use super::{write_command, Model};
 
 /// ST7735s SPI display with Reset pin
 /// Only SPI with DC pin interface is supported
-pub struct ST7735s;
+pub struct ST7735s(DisplayOptions);
 
 impl Model for ST7735s {
     type ColorFormat = Rgb565;
 
-    fn new() -> Self {
-        Self
+    fn new(options: DisplayOptions) -> Self {
+        Self(options)
     }
 
     fn init<RST, DELAY, DI>(
@@ -24,14 +24,13 @@ impl Model for ST7735s {
         di: &mut DI,
         rst: &mut Option<RST>,
         delay: &mut DELAY,
-        options: DisplayOptions,
     ) -> Result<u8, Error<RST::Error>>
     where
         RST: OutputPin,
         DELAY: DelayUs<u32>,
         DI: WriteOnlyDataCommand,
     {
-        let madctl = options.madctl() ^ 0b0000_1000; // this model has flipped RGB/BGR bit
+        let madctl = self.options().madctl() ^ 0b0000_1000; // this model has flipped RGB/BGR bit
 
         match rst {
             Some(ref mut rst) => self.hard_reset(rst, delay)?,
@@ -94,17 +93,15 @@ impl Model for ST7735s {
     }
 
     fn display_size(&self, orientation: Orientation) -> (u16, u16) {
-        match orientation {
-            Orientation::Portrait(_) | Orientation::PortraitInverted(_) => (80, 160),
-            Orientation::Landscape(_) | Orientation::LandscapeInverted(_) => (160, 80),
-        }
+        self.0.display_size(80, 160, orientation)
     }
 
     fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
-        match orientation {
-            Orientation::Portrait(_) | Orientation::PortraitInverted(_) => (132, 162),
-            Orientation::Landscape(_) | Orientation::LandscapeInverted(_) => (162, 132),
-        }
+        self.0.framebuffer_size(132, 162, orientation)
+    }
+
+    fn options(&self) -> &DisplayOptions {
+        &self.0
     }
 }
 
@@ -124,9 +121,10 @@ where
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
     /// * `rst` - display hard reset [OutputPin]
     /// * `model` - the display [Model]
+    /// * `options` - the [DisplayOptions] for this display/model
     ///
-    pub fn st7735s(di: DI, rst: RST) -> Self {
-        Self::with_model(di, Some(rst), ST7735s::new())
+    pub fn st7735s(di: DI, rst: RST, options: DisplayOptions) -> Self {
+        Self::with_model(di, Some(rst), ST7735s::new(options))
     }
 }
 
@@ -142,8 +140,9 @@ where
     ///
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
     /// * `model` - the display [Model]
+    /// * `options` - the [DisplayOptions] for this display/model
     ///
-    pub fn st7735s_without_rst(di: DI) -> Self {
-        Self::with_model(di, None, ST7735s::new())
+    pub fn st7735s_without_rst(di: DI, options: DisplayOptions) -> Self {
+        Self::with_model(di, None, ST7735s::new(options))
     }
 }

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -120,7 +120,6 @@ where
     ///
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
     /// * `rst` - display hard reset [OutputPin]
-    /// * `model` - the display [Model]
     /// * `options` - the [DisplayOptions] for this display/model
     ///
     pub fn st7735s(di: DI, rst: RST, options: DisplayOptions) -> Self {
@@ -139,7 +138,6 @@ where
     /// # Arguments
     ///
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
-    /// * `model` - the display [Model]
     /// * `options` - the [DisplayOptions] for this display/model
     ///
     pub fn st7735s_without_rst(di: DI, options: DisplayOptions) -> Self {

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -2,7 +2,6 @@ use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
 use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
-use crate::no_pin::NoPin;
 use crate::DisplayOptions;
 use crate::{instruction::Instruction, Display, Error};
 
@@ -122,25 +121,7 @@ where
     /// * `rst` - display hard reset [OutputPin]
     /// * `options` - the [DisplayOptions] for this display/model
     ///
-    pub fn st7735s(di: DI, rst: RST, options: DisplayOptions) -> Self {
-        Self::with_model(di, Some(rst), ST7735s::new(options))
-    }
-}
-
-impl<DI> Display<DI, NoPin, ST7735s>
-where
-    DI: WriteOnlyDataCommand,
-{
-    ///
-    /// Creates a new [Display] instance with [ST7735s] as the [Model] without
-    /// a hard reset Pin
-    ///
-    /// # Arguments
-    ///
-    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
-    /// * `options` - the [DisplayOptions] for this display/model
-    ///
-    pub fn st7735s_without_rst(di: DI, options: DisplayOptions) -> Self {
-        Self::with_model(di, None, ST7735s::new(options))
+    pub fn st7735s(di: DI, rst: Option<RST>, options: DisplayOptions) -> Self {
+        Self::with_model(di, rst, ST7735s::new(options))
     }
 }

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -2,24 +2,23 @@ use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
 use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
-use crate::DisplayOptions;
 use crate::{instruction::Instruction, Error};
 
-use super::{write_command, Model};
+use super::{write_command, Model, ModelOptions};
 
 /// Module containing all ST7789 variants and helper constructors for [Display]
 mod variants;
 
 /// ST7789 SPI display with Reset pin
 /// Only SPI with DC pin interface is supported
-pub struct ST7789(DisplayOptions);
+pub struct ST7789(ModelOptions);
 
 impl Model for ST7789 {
     type ColorFormat = Rgb565;
 
-    fn new(options: DisplayOptions) -> Self {
+    fn new(options: ModelOptions) -> Self {
         // use 240x240 display if not specified by user in options
-        Self(options.with_display_size(240, 320))
+        Self(options)
     }
 
     fn init<RST, DELAY, DI>(
@@ -80,7 +79,7 @@ impl Model for ST7789 {
     //     self.0.framebuffer_size(240, 320, orientation)
     // }
 
-    fn options(&self) -> &DisplayOptions {
+    fn options(&self) -> &ModelOptions {
         &self.0
     }
 }

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -98,7 +98,6 @@ where
     ///
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
     /// * `rst` - display hard reset [OutputPin]
-    /// * `model` - the display [Model]
     /// * `options` - the [DisplayOptions] for this display/model
     ///
     pub fn st7789(di: DI, rst: RST, options: DisplayOptions) -> Self {
@@ -113,7 +112,6 @@ where
     ///
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
     /// * `rst` - display hard reset [OutputPin]
-    /// * `model` - the display [Model]
     /// * `options` - the [DisplayOptions] for this display/model
     ///
     pub fn st7789_240x240(di: DI, rst: RST, options: DisplayOptions) -> Self {
@@ -132,7 +130,6 @@ where
     ///
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
     /// * `rst` - display hard reset [OutputPin]
-    /// * `model` - the display [Model]
     /// * `options` - the [DisplayOptions] for this display/model
     ///
     pub fn st7789_135x240(di: DI, rst: RST, mut options: DisplayOptions) -> Self {
@@ -155,7 +152,6 @@ where
     /// # Arguments
     ///
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
-    /// * `model` - the display [Model]
     /// * `options` - the [DisplayOptions] for this display/model
     ///
     pub fn st7789_without_rst(di: DI, options: DisplayOptions) -> Self {

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -2,11 +2,13 @@ use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
 use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
-use crate::no_pin::NoPin;
 use crate::DisplayOptions;
-use crate::{instruction::Instruction, Display, Error};
+use crate::{instruction::Instruction, Error};
 
 use super::{write_command, Model};
+
+/// Module containing all ST7789 variants and helper constructors for [Display]
+mod variants;
 
 /// ST7789 SPI display with Reset pin
 /// Only SPI with DC pin interface is supported
@@ -80,81 +82,5 @@ impl Model for ST7789 {
 
     fn options(&self) -> &DisplayOptions {
         &self.0
-    }
-}
-
-// simplified constructor on Display
-
-impl<DI, RST> Display<DI, RST, ST7789>
-where
-    DI: WriteOnlyDataCommand,
-    RST: OutputPin,
-{
-    ///
-    /// Creates a new [Display] instance with [ST7789] as the [Model] with a
-    /// hard reset Pin and display size of 240x320
-    ///
-    /// # Arguments
-    ///
-    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
-    /// * `rst` - display hard reset [OutputPin]
-    /// * `options` - the [DisplayOptions] for this display/model
-    ///
-    pub fn st7789(di: DI, rst: RST, options: DisplayOptions) -> Self {
-        Self::with_model(di, Some(rst), ST7789::new(options))
-    }
-
-    ///
-    /// Creates a new [Display] instance with [ST7789] as the [Model] with a
-    /// hard reset Pin and display size of 240x240
-    ///
-    /// # Arguments
-    ///
-    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
-    /// * `rst` - display hard reset [OutputPin]
-    /// * `options` - the [DisplayOptions] for this display/model
-    ///
-    pub fn st7789_240x240(di: DI, rst: RST, options: DisplayOptions) -> Self {
-        Self::with_model(
-            di,
-            Some(rst),
-            ST7789::new(options.with_display_size(240, 240)),
-        )
-    }
-
-    ///
-    /// Creates a new [Display] instance with [ST7789] as the [Model] with a
-    /// hard reset Pin and display size of 135x240
-    ///
-    /// # Arguments
-    ///
-    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
-    /// * `rst` - display hard reset [OutputPin]
-    /// * `options` - the [DisplayOptions] for this display/model
-    ///
-    pub fn st7789_135x240(di: DI, rst: RST, mut options: DisplayOptions) -> Self {
-        // pico v1 is cropped to 135x240 size with an offset of (40, 53)
-        options.window_offset = (52, 40);
-        options.display_size = (135, 240);
-        options.framebuffer_size = (135, 240);
-        Self::with_model(di, Some(rst), ST7789::new(options))
-    }
-}
-
-impl<DI> Display<DI, NoPin, ST7789>
-where
-    DI: WriteOnlyDataCommand,
-{
-    ///
-    /// Creates a new [Display] instance with [ST7789] as the [Model] without
-    /// a hard reset Pin with display size of 240x320
-    ///
-    /// # Arguments
-    ///
-    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
-    /// * `options` - the [DisplayOptions] for this display/model
-    ///
-    pub fn st7789_without_rst(di: DI, options: DisplayOptions) -> Self {
-        Self::with_model(di, None, ST7789::new(options))
     }
 }

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -3,8 +3,8 @@ use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 use crate::no_pin::NoPin;
+use crate::DisplayOptions;
 use crate::{instruction::Instruction, Display, Error};
-use crate::{DisplayOptions, Orientation};
 
 use super::{write_command, Model};
 
@@ -16,7 +16,8 @@ impl Model for ST7789 {
     type ColorFormat = Rgb565;
 
     fn new(options: DisplayOptions) -> Self {
-        Self(options)
+        // use 240x240 display if not specified by user in options
+        Self(options.with_display_size(240, 240))
     }
 
     fn init<RST, DELAY, DI>(
@@ -69,13 +70,13 @@ impl Model for ST7789 {
         di.send_data(buf)
     }
 
-    fn display_size(&self, orientation: Orientation) -> (u16, u16) {
-        self.0.display_size(240, 240, orientation)
-    }
+    // fn display_size(&self, orientation: Orientation) -> (u16, u16) {
+    //     self.0.display_size(240, 240, orientation)
+    // }
 
-    fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
-        self.0.framebuffer_size(240, 320, orientation)
-    }
+    // fn framebuffer_size(&self, orientation: Orientation) -> (u16, u16) {
+    //     self.0.framebuffer_size(240, 320, orientation)
+    // }
 
     fn options(&self) -> &DisplayOptions {
         &self.0

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -137,7 +137,7 @@ where
     ///
     pub fn st7789_135x240(di: DI, rst: RST, mut options: DisplayOptions) -> Self {
         // pico v1 is cropped to 135x240 size with an offset of (40, 53)
-        options.window_offset = (40, 53);
+        options.window_offset = (52, 40);
         options.display_size = (135, 240);
         options.framebuffer_size = (135, 240);
         Self::with_model(di, Some(rst), ST7789::new(options))

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -17,7 +17,7 @@ impl Model for ST7789 {
 
     fn new(options: DisplayOptions) -> Self {
         // use 240x240 display if not specified by user in options
-        Self(options.with_display_size(240, 240))
+        Self(options.with_display_size(240, 320))
     }
 
     fn init<RST, DELAY, DI>(
@@ -92,7 +92,7 @@ where
 {
     ///
     /// Creates a new [Display] instance with [ST7789] as the [Model] with a
-    /// hard reset Pin
+    /// hard reset Pin and display size of 240x320
     ///
     /// # Arguments
     ///
@@ -104,6 +104,44 @@ where
     pub fn st7789(di: DI, rst: RST, options: DisplayOptions) -> Self {
         Self::with_model(di, Some(rst), ST7789::new(options))
     }
+
+    ///
+    /// Creates a new [Display] instance with [ST7789] as the [Model] with a
+    /// hard reset Pin and display size of 240x240
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `rst` - display hard reset [OutputPin]
+    /// * `model` - the display [Model]
+    /// * `options` - the [DisplayOptions] for this display/model
+    ///
+    pub fn st7789_240x240(di: DI, rst: RST, options: DisplayOptions) -> Self {
+        Self::with_model(
+            di,
+            Some(rst),
+            ST7789::new(options.with_display_size(240, 240)),
+        )
+    }
+
+    ///
+    /// Creates a new [Display] instance with [ST7789] as the [Model] with a
+    /// hard reset Pin and display size of 135x240
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `rst` - display hard reset [OutputPin]
+    /// * `model` - the display [Model]
+    /// * `options` - the [DisplayOptions] for this display/model
+    ///
+    pub fn st7789_135x240(di: DI, rst: RST, mut options: DisplayOptions) -> Self {
+        // pico v1 is cropped to 135x240 size with an offset of (40, 53)
+        options.window_offset = (40, 53);
+        options.display_size = (135, 240);
+        options.framebuffer_size = (135, 240);
+        Self::with_model(di, Some(rst), ST7789::new(options))
+    }
 }
 
 impl<DI> Display<DI, NoPin, ST7789>
@@ -112,7 +150,7 @@ where
 {
     ///
     /// Creates a new [Display] instance with [ST7789] as the [Model] without
-    /// a hard reset Pin
+    /// a hard reset Pin with display size of 240x320
     ///
     /// # Arguments
     ///

--- a/src/models/st7789/variants.rs
+++ b/src/models/st7789/variants.rs
@@ -76,10 +76,14 @@ where
 
 // ST7789 pico1 variant with variable offset
 pub(crate) fn pico1_offset(orientation: Orientation) -> (u16, u16) {
-    // PortraitInverted(false) and Landscape(true) x offset is 53,
-    // for Landscape(false) and PortraitInverted(true) it is 52
     match orientation {
-        Orientation::Landscape(true) | Orientation::PortraitInverted(false) => (53, 40),
-        _ => (52, 40),
+        Orientation::Portrait(false) => (52, 40),
+        Orientation::Portrait(true) => (53, 40),
+        Orientation::Landscape(false) => (40, 52),
+        Orientation::Landscape(true) => (40, 53),
+        Orientation::PortraitInverted(false) => (53, 40),
+        Orientation::PortraitInverted(true) => (52, 40),
+        Orientation::LandscapeInverted(false) => (40, 53),
+        Orientation::LandscapeInverted(true) => (40, 52),
     }
 }

--- a/src/models/st7789/variants.rs
+++ b/src/models/st7789/variants.rs
@@ -1,7 +1,10 @@
 use display_interface::WriteOnlyDataCommand;
 use embedded_hal::digital::v2::OutputPin;
 
-use crate::{models::Model, Display, DisplayOptions, Orientation};
+use crate::{
+    models::{Model, ModelOptions},
+    Display, DisplayOptions, Orientation,
+};
 
 use super::ST7789;
 
@@ -21,7 +24,11 @@ where
     /// * `options` - the [DisplayOptions] for this display/model
     ///
     pub fn st7789(di: DI, rst: Option<RST>, options: DisplayOptions) -> Self {
-        Self::with_model(di, rst, ST7789::new(options.with_display_size(240, 320)))
+        Self::with_model(
+            di,
+            rst,
+            ST7789::new(ModelOptions::with_display_size(options, 240, 320)),
+        )
     }
 
     ///
@@ -35,7 +42,11 @@ where
     /// * `options` - the [DisplayOptions] for this display/model
     ///
     pub fn st7789_240x240(di: DI, rst: Option<RST>, options: DisplayOptions) -> Self {
-        Self::with_model(di, rst, ST7789::new(options.with_display_size(240, 240)))
+        Self::with_model(
+            di,
+            rst,
+            ST7789::new(ModelOptions::with_display_size(options, 240, 240)),
+        )
     }
 
     ///
@@ -48,12 +59,18 @@ where
     /// * `rst` - display hard reset [OutputPin]
     /// * `options` - the [DisplayOptions] for this display/model
     ///
-    pub fn st7789_pico1(di: DI, rst: Option<RST>, mut options: DisplayOptions) -> Self {
+    pub fn st7789_pico1(di: DI, rst: Option<RST>, options: DisplayOptions) -> Self {
         // pico v1 is cropped to 135x240 size with an offset of (40, 53)
-        options.window_offset_handler = pico1_offset;
-        options.display_size = (135, 240);
-        options.framebuffer_size = (135, 240);
-        Self::with_model(di, rst, ST7789::new(options))
+        Self::with_model(
+            di,
+            rst,
+            ST7789::new(ModelOptions::with_all(
+                options,
+                (135, 240),
+                (135, 240),
+                pico1_offset,
+            )),
+        )
     }
 }
 

--- a/src/models/st7789/variants.rs
+++ b/src/models/st7789/variants.rs
@@ -1,0 +1,68 @@
+use display_interface::WriteOnlyDataCommand;
+use embedded_hal::digital::v2::OutputPin;
+
+use crate::{models::Model, Display, DisplayOptions, Orientation};
+
+use super::ST7789;
+
+impl<DI, RST> Display<DI, RST, ST7789>
+where
+    DI: WriteOnlyDataCommand,
+    RST: OutputPin,
+{
+    ///
+    /// Creates a new [Display] instance with [ST7789] as the [Model] with
+    /// general variant using display size of 240x320
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `rst` - display hard reset [OutputPin]
+    /// * `options` - the [DisplayOptions] for this display/model
+    ///
+    pub fn st7789(di: DI, rst: Option<RST>, options: DisplayOptions) -> Self {
+        Self::with_model(di, rst, ST7789::new(options.with_display_size(240, 320)))
+    }
+
+    ///
+    /// Creates a new [Display] instance with [ST7789] as the [Model] with
+    /// general variant using display size of 240x240
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `rst` - display hard reset [OutputPin]
+    /// * `options` - the [DisplayOptions] for this display/model
+    ///
+    pub fn st7789_240x240(di: DI, rst: Option<RST>, options: DisplayOptions) -> Self {
+        Self::with_model(di, rst, ST7789::new(options.with_display_size(240, 240)))
+    }
+
+    ///
+    /// Creates a new [Display] instance with [ST7789] as the [Model] with
+    /// pico1 variant using display size of 135x240 and a clipping offset
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `rst` - display hard reset [OutputPin]
+    /// * `options` - the [DisplayOptions] for this display/model
+    ///
+    pub fn st7789_pico1(di: DI, rst: Option<RST>, mut options: DisplayOptions) -> Self {
+        // pico v1 is cropped to 135x240 size with an offset of (40, 53)
+        options.window_offset_handler = pico1_offset;
+        options.display_size = (135, 240);
+        options.framebuffer_size = (135, 240);
+        Self::with_model(di, rst, ST7789::new(options))
+    }
+}
+
+// ST7789 pico1 variant with variable offset
+pub(crate) fn pico1_offset(orientation: Orientation) -> (u16, u16) {
+    // PortraitInverted(false) and Landscape(true) x offset is 53,
+    // for Landscape(false) and PortraitInverted(true) it is 52
+    match orientation {
+        Orientation::Landscape(true) | Orientation::PortraitInverted(false) => (53, 40),
+        _ => (52, 40),
+    }
+}


### PR DESCRIPTION
This PR tries to address #27 and #20 by refactoring the `DisplayOptions` and `init` paths so variants of the same `Display` and `Model` can be used with different physical display sizes.

This also adds support for "cropped" display variants in which the display framebuffer is bigger but the visible display is smaller as well as "offset" from the `(0, 0)` coordinates internally.