### PR TITLE
Support for ST7789 with display of 240x240 but frame buffer of 240x320

### DIFF
--- a/src/models/st7789/variants.rs
+++ b/src/models/st7789/variants.rs
@@ -66,7 +66,7 @@ where
                 options,
                 (240, 240),
                 (240, 320),
-                st7789_offset,
+                y80_offset,
             )),
         )
     }
@@ -110,8 +110,8 @@ pub(crate) fn pico1_offset(orientation: Orientation) -> (u16, u16) {
     }
 }
 
-// ST7789 pico1 variant with variable offset
-pub(crate) fn st7789_offset(orientation: Orientation) -> (u16, u16) {
+// ST7789 240x240 with a frame buffer of 240x320
+pub(crate) fn y80_offset(orientation: Orientation) -> (u16, u16) {
     match orientation {
         Orientation::Portrait(false) => (0, 0),
         Orientation::Portrait(true) => (0, 0),

--- a/src/models/st7789/variants.rs
+++ b/src/models/st7789/variants.rs
@@ -110,7 +110,8 @@ pub(crate) fn pico1_offset(orientation: Orientation) -> (u16, u16) {
     }
 }
 
-// ST7789 240x240 with a frame buffer of 240x320
+// An offset of 80 y pixels for the st7789 when the display is 240x240 but the frame buffer
+// is 240x320
 pub(crate) fn y80_offset(orientation: Orientation) -> (u16, u16) {
     match orientation {
         Orientation::Portrait(false) => (0, 0),

--- a/src/models/st7789/variants.rs
+++ b/src/models/st7789/variants.rs
@@ -48,6 +48,28 @@ where
             ST7789::new(ModelOptions::with_display_size(options, 240, 240)),
         )
     }
+    ///
+    /// Creates a new [Display] instance with [ST7789] as the [Model] with
+    /// general variant using display size of 240x240 but a frame buffer of 240x320 and adjusting the offset
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `rst` - display hard reset [OutputPin]
+    /// * `options` - the [DisplayOptions] for this display/model
+    ///
+    pub fn st7789_240x240_b240x320(di: DI, rst: Option<RST>, options: DisplayOptions) -> Self {
+        Self::with_model(
+            di,
+            rst,
+            ST7789::new(ModelOptions::with_all(
+                options,
+                (240, 240),
+                (240, 320),
+                st7789_offset,
+            )),
+        )
+    }
 
     ///
     /// Creates a new [Display] instance with [ST7789] as the [Model] with
@@ -85,5 +107,19 @@ pub(crate) fn pico1_offset(orientation: Orientation) -> (u16, u16) {
         Orientation::PortraitInverted(true) => (52, 40),
         Orientation::LandscapeInverted(false) => (40, 53),
         Orientation::LandscapeInverted(true) => (40, 52),
+    }
+}
+
+// ST7789 pico1 variant with variable offset
+pub(crate) fn st7789_offset(orientation: Orientation) -> (u16, u16) {
+    match orientation {
+        Orientation::Portrait(false) => (0, 0),
+        Orientation::Portrait(true) => (0, 0),
+        Orientation::Landscape(false) => (0, 0),
+        Orientation::Landscape(true) => (0, 0),
+        Orientation::PortraitInverted(false) => (0, 80),
+        Orientation::PortraitInverted(true) => (0, 80),
+        Orientation::LandscapeInverted(false) => (80, 0),
+        Orientation::LandscapeInverted(true) => (80, 0),
     }
 }


### PR DESCRIPTION
Some St7789 have a display of 240x240 but a frame buffer of 240x320 which causes issue when using inverted orientation since
the image is draws in  valid the valid frame buffer pixels, but are not show since they do not exist on the display itself.

Fixes #29. Piggy backed on what was done for the pico display by simply using an offset.

The `st7789_240x240_b240x320` is quite long but I'm not sure how to keep it short and descriptive so I am open to suggestions.