### PR TITLE
remove inversal on st7735s, fixes #33

### DIFF
--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -36,8 +36,6 @@ impl Model for ST7735s {
         write_command(di, Instruction::SLPOUT, &[])?; // turn off sleep
         delay.delay_us(120_000);
 
-        write_command(di, Instruction::INVON, &[])?; // turn inversion on
-        write_command(di, Instruction::INVON, &[])?; // turn inversion on
         write_command(di, Instruction::FRMCTR1, &[0x05, 0x3A, 0x3A])?; // set frame rate
         write_command(di, Instruction::FRMCTR2, &[0x05, 0x3A, 0x3A])?; // set frame rate
         write_command(


### PR DESCRIPTION
This removes the inverse during init on st7735s hopefully fixing #33 