### PR TITLE
add invert_colors support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+ - added `ModelOptions::invert_colors` flag
+ - added `Builder::with_invert_colors(bool)` method
+
+### Changed
+
+ - `Model::init` changed to expect `options: &ModelOptions`
+
 ### Removed
 
  - removed duplicated `INVON` call in `ST7735s` model init

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,15 @@
 # Migration guide for MIPIDSI driver
 
+## v0.5 -> 0.6
+
+### Users
+
+* no change, addition of `Builder::with_invert_colors(bool)` allows more combinations of display variants.
+
+### Model writers and specific variants
+
+`Model::init` now expects the `options: &ModelOptions` instead of just `madcl: u8` argument. This allows the use of the `invert_colors` field during init.
+
 ## v0.4 -> 0.5
 
 ### Users

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -45,6 +45,14 @@ where
     }
 
     ///
+    /// Sets the invert color flag
+    ///
+    pub fn with_invert_colors(mut self, invert_colors: bool) -> Self {
+        self.options.invert_colors = invert_colors;
+        self
+    }
+
+    ///
     /// Sets the [ColorOrder]
     ///
     pub fn with_color_order(mut self, color_order: ColorOrder) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ where
         delay_source: &mut impl DelayUs<u32>,
     ) -> Result<u8, InitError<RST::Error>> {
         self.model
-            .init(&mut self.di, delay_source, self.madctl, &mut self.rst)
+            .init(&mut self.di, delay_source, &self.options, &mut self.rst)
     }
     ///
     /// Returns currently set [Orientation]

--- a/src/models.rs
+++ b/src/models.rs
@@ -23,7 +23,7 @@ pub trait Model {
         &mut self,
         di: &mut DI,
         delay: &mut DELAY,
-        madctl: u8,
+        options: &ModelOptions,
         rst: &mut Option<RST>,
     ) -> Result<u8, InitError<RST::Error>>
     where

--- a/src/models/ili9342c.rs
+++ b/src/models/ili9342c.rs
@@ -128,11 +128,7 @@ where
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
     ///
     pub fn ili9342c_rgb565(di: DI) -> Self {
-        Self::new(
-            di,
-            ILI9342CRgb565,
-            ModelOptions::with_sizes((320, 240), (320, 240)),
-        )
+        Self::with_model(di, ILI9342CRgb565)
     }
 }
 
@@ -149,11 +145,7 @@ where
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
     ///
     pub fn ili9342c_rgb666(di: DI) -> Self {
-        Self::new(
-            di,
-            ILI9342CRgb666,
-            ModelOptions::with_sizes((320, 240), (320, 240)),
-        )
+        Self::with_model(di, ILI9342CRgb666)
     }
 }
 
@@ -167,7 +159,7 @@ where
     DELAY: DelayUs<u32>,
     DI: WriteOnlyDataCommand,
 {
-    let madctl = options.madctl() ^ 0b0000_1000; // this model has flipped RGB/BGR bit;
+    let madctl = options.madctl();
 
     write_command(di, Instruction::SLPOUT, &[])?; // turn off sleep
     write_command(di, Instruction::MADCTL, &[madctl])?; // left -> right, bottom -> top RGB

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -25,7 +25,7 @@ impl Model for ST7735s {
         DELAY: DelayUs<u32>,
         DI: WriteOnlyDataCommand,
     {
-        let madctl = options.madctl() ^ 0b0000_1000; // this model has flipped RGB/BGR bit
+        let madctl = options.madctl();
 
         match rst {
             Some(ref mut rst) => self.hard_reset(rst, delay)?,
@@ -88,7 +88,7 @@ impl Model for ST7735s {
     }
 
     fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((80, 160), (132, 162))
+        ModelOptions::with_sizes((80, 160), (132, 162)).with_invert_colors(true)
     }
 }
 
@@ -109,6 +109,6 @@ where
     /// * `options` - the [DisplayOptions] for this display/model
     ///
     pub fn st7735s(di: DI) -> Self {
-        Self::new(di, ST7735s, ModelOptions::with_sizes((80, 160), (132, 162)))
+        Self::with_model(di, ST7735s)
     }
 }

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -17,7 +17,7 @@ impl Model for ST7735s {
         &mut self,
         di: &mut DI,
         delay: &mut DELAY,
-        madctl: u8,
+        options: &ModelOptions,
         rst: &mut Option<RST>,
     ) -> Result<u8, InitError<RST::Error>>
     where
@@ -25,7 +25,7 @@ impl Model for ST7735s {
         DELAY: DelayUs<u32>,
         DI: WriteOnlyDataCommand,
     {
-        let madctl = madctl ^ 0b0000_1000; // this model has flipped RGB/BGR bit
+        let madctl = options.madctl() ^ 0b0000_1000; // this model has flipped RGB/BGR bit
 
         match rst {
             Some(ref mut rst) => self.hard_reset(rst, delay)?,
@@ -36,7 +36,7 @@ impl Model for ST7735s {
         write_command(di, Instruction::SLPOUT, &[])?; // turn off sleep
         delay.delay_us(120_000);
 
-        write_command(di, Instruction::INVON, &[])?; // turn inversion on
+        write_command(di, options.invert_command(), &[])?; // set color inversion
         write_command(di, Instruction::FRMCTR1, &[0x05, 0x3A, 0x3A])?; // set frame rate
         write_command(di, Instruction::FRMCTR2, &[0x05, 0x3A, 0x3A])?; // set frame rate
         write_command(

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -67,6 +67,6 @@ impl Model for ST7789 {
     }
 
     fn default_options() -> crate::ModelOptions {
-        ModelOptions::with_sizes((240, 320), (240, 320))
+        ModelOptions::with_sizes((240, 320), (240, 320)).with_invert_colors(true)
     }
 }

--- a/src/models/st7789/variants.rs
+++ b/src/models/st7789/variants.rs
@@ -33,7 +33,7 @@ where
         Self::new(
             di,
             ST7789,
-            ModelOptions::with_all((135, 240), (135, 240), pico1_offset),
+            ModelOptions::with_all((135, 240), (135, 240), pico1_offset).with_invert_colors(true),
         )
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -66,6 +66,11 @@ impl ModelOptions {
         }
     }
 
+    pub fn with_invert_colors(mut self, invert_colors: bool) -> Self {
+        self.invert_colors = invert_colors;
+        self
+    }
+
     ///
     /// Returns MADCTL register value for given display options
     ///

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,5 +1,7 @@
 //! Module holding [ModelOptions] and other helper types for [super::Display]
 
+use crate::instruction::Instruction;
+
 ///
 /// [ModelOptions] hold all the various settings that can impact a particular [super::Model]
 /// `display_size` being set is the minimum requirement.
@@ -10,6 +12,8 @@ pub struct ModelOptions {
     pub(crate) color_order: ColorOrder,
     /// Initial display orientation (without inverts)
     pub(crate) orientation: Orientation,
+    /// Whether to invert colors for this display/model (INVON)
+    pub(crate) invert_colors: bool,
     /// Set to make display vertical refresh bottom to top
     pub(crate) invert_vertical_refresh: bool,
     /// Set to make display horizontal refresh right to left
@@ -32,6 +36,7 @@ impl ModelOptions {
         Self {
             color_order: ColorOrder::default(),
             orientation: Orientation::default(),
+            invert_colors: false,
             invert_horizontal_refresh: false,
             invert_vertical_refresh: false,
             window_offset_handler: no_offset,
@@ -52,6 +57,7 @@ impl ModelOptions {
         Self {
             color_order: ColorOrder::default(),
             orientation: Orientation::default(),
+            invert_colors: false,
             invert_horizontal_refresh: false,
             invert_vertical_refresh: false,
             window_offset_handler,
@@ -77,6 +83,13 @@ impl ModelOptions {
         }
 
         value
+    }
+
+    pub fn invert_command(&self) -> Instruction {
+        match self.invert_colors {
+            false => Instruction::INVOFF,
+            true => Instruction::INVON,
+        }
     }
 
     ///


### PR DESCRIPTION
Adds `Builder::invert_colors(bool)` to fix #33 and surplant #34 