### PR TITLE
Add ILI9341 and use display-driver-hal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ display-interface = "0.4.1"
 embedded-graphics-core = "0.3.3"
 embedded-hal = "0.2.7"
 nb = "1.0.0"
+display-driver-hal = { git = "https://github.com/embedded-graphics/display-driver-hal.git" }
 
 [dependencies.heapless]
 optional = true

--- a/src/models.rs
+++ b/src/models.rs
@@ -4,11 +4,13 @@ use embedded_graphics_core::prelude::RgbColor;
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 // existing model implementations
+mod ili9341;
 mod ili9342c;
 mod ili9486;
 mod st7735s;
 mod st7789;
 
+pub use ili9341::*;
 pub use ili9342c::*;
 pub use ili9486::*;
 pub use st7735s::*;

--- a/src/models/ili9341.rs
+++ b/src/models/ili9341.rs
@@ -1,0 +1,179 @@
+use display_interface::{DataFormat, WriteOnlyDataCommand};
+use embedded_graphics_core::{
+    pixelcolor::{Rgb565, Rgb666},
+    prelude::{IntoStorage, RgbColor},
+};
+use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+
+use crate::{error::InitError, instruction::Instruction, Builder, Error, ModelOptions};
+
+use super::{write_command, Model};
+
+/// ILI9341 display with Reset pin
+/// in Rgb565 color mode
+/// Backlight pin is not controlled
+pub struct ILI9341Rgb565;
+
+/// ILI9341 display with Reset pin
+/// in Rgb666 color mode
+/// Backlight pin is not controlled
+pub struct ILI9341Rgb666;
+
+impl Model for ILI9341Rgb565 {
+    type ColorFormat = Rgb565;
+
+    fn init<RST, DELAY, DI>(
+        &mut self,
+        di: &mut DI,
+        delay: &mut DELAY,
+        madctl: u8,
+        rst: &mut Option<RST>,
+    ) -> Result<u8, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs<u32>,
+        DI: WriteOnlyDataCommand,
+    {
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay)?,
+            None => write_command(di, Instruction::SWRESET, &[])?,
+        }
+
+        delay.delay_us(120_000);
+
+        write_command(di, Instruction::COLMOD, &[0b0101_0101])?; // 16bit 65k colors
+
+        Ok(init_common(di, delay, madctl)?)
+    }
+
+    fn write_pixels<DI, I>(&mut self, di: &mut DI, colors: I) -> Result<(), Error>
+    where
+        DI: WriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        write_command(di, Instruction::RAMWR, &[])?;
+        let mut iter = colors.into_iter().map(|c| c.into_storage());
+
+        let buf = DataFormat::U16BEIter(&mut iter);
+        di.send_data(buf)
+    }
+
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((240, 320), (240, 320))
+    }
+}
+
+impl Model for ILI9341Rgb666 {
+    type ColorFormat = Rgb666;
+
+    fn init<RST, DELAY, DI>(
+        &mut self,
+        di: &mut DI,
+        delay: &mut DELAY,
+        madctl: u8,
+        rst: &mut Option<RST>,
+    ) -> Result<u8, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs<u32>,
+        DI: WriteOnlyDataCommand,
+    {
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay)?,
+            None => write_command(di, Instruction::SWRESET, &[])?,
+        }
+
+        delay.delay_us(120_000);
+
+        write_command(di, Instruction::COLMOD, &[0b0110_0110])?; // 18bit 262k colors
+
+        Ok(init_common(di, delay, madctl)?)
+    }
+
+    fn write_pixels<DI, I>(&mut self, di: &mut DI, colors: I) -> Result<(), Error>
+    where
+        DI: WriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        write_command(di, Instruction::RAMWR, &[])?;
+        let mut iter = colors.into_iter().flat_map(|c| {
+            let red = c.r() << 2;
+            let green = c.g() << 2;
+            let blue = c.b() << 2;
+            [red, green, blue]
+        });
+
+        let buf = DataFormat::U8Iter(&mut iter);
+        di.send_data(buf)
+    }
+
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((240, 320), (240, 320))
+    }
+}
+
+// simplified constructor for Display
+
+impl<DI> Builder<DI, ILI9341Rgb565>
+where
+    DI: WriteOnlyDataCommand,
+{
+    ///
+    /// Creates a new [Display] instance with [ILI9341] as the [Model]
+    /// with the default framebuffer size and display size of 240x320
+    /// *WARNING* Rgb565 only works on non-SPI setups with the ILI9341!
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    ///
+    pub fn ili9341_rgb565(di: DI) -> Self {
+        Self::new(
+            di,
+            ILI9341Rgb565,
+            ModelOptions::with_sizes((240, 320), (240, 320)),
+        )
+    }
+}
+
+impl<DI> Builder<DI, ILI9341Rgb666>
+where
+    DI: WriteOnlyDataCommand,
+{
+    ///
+    /// Creates a new [Display] instance with [ILI9341] as the [Model]
+    /// with the default framebuffer size and display size of 240x320
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    ///
+    pub fn ili9341_rgb666(di: DI) -> Self {
+        Self::new(
+            di,
+            ILI9341Rgb666,
+            ModelOptions::with_sizes((240, 320), (240, 320)),
+        )
+    }
+}
+
+// common init for all color format models
+fn init_common<DELAY, DI>(di: &mut DI, delay: &mut DELAY, madctl: u8) -> Result<u8, Error>
+where
+    DELAY: DelayUs<u32>,
+    DI: WriteOnlyDataCommand,
+{
+    let madctl = madctl ^ 0b0000_1000; // this model has flipped RGB/BGR bit;
+
+    write_command(di, Instruction::SLPOUT, &[])?; // turn off sleep
+    write_command(di, Instruction::MADCTL, &[madctl])?; // left -> right, bottom -> top RGB
+    write_command(di, Instruction::INVCO, &[0x0])?; //Inversion Control [00]
+
+    write_command(di, Instruction::NORON, &[])?; // turn to normal mode
+    write_command(di, Instruction::DISPON, &[])?; // turn on display
+
+    // DISPON requires some time otherwise we risk SPI data issues
+    delay.delay_us(120_000);
+
+    Ok(madctl)
+}

--- a/src/models/st7789/variants.rs
+++ b/src/models/st7789/variants.rs
@@ -1,6 +1,6 @@
 use display_interface::WriteOnlyDataCommand;
 
-use crate::{Builder, ModelOptions, Orientation};
+use crate::{Builder, ModelOptions};
 
 use super::ST7789;
 
@@ -40,14 +40,17 @@ where
 
 // ST7789 pico1 variant with variable offset
 pub(crate) fn pico1_offset(options: &ModelOptions) -> (u16, u16) {
-    match options.orientation() {
-        Orientation::Portrait(false) => (52, 40),
-        Orientation::Portrait(true) => (53, 40),
-        Orientation::Landscape(false) => (40, 52),
-        Orientation::Landscape(true) => (40, 53),
-        Orientation::PortraitInverted(false) => (53, 40),
-        Orientation::PortraitInverted(true) => (52, 40),
-        Orientation::LandscapeInverted(false) => (40, 53),
-        Orientation::LandscapeInverted(true) => (40, 52),
-    }
+    (0, 0)
+
+    //TODO: fix
+    // match options.orientation() {
+    //     Orientation::Portrait(false) => (52, 40),
+    //     Orientation::Portrait(true) => (53, 40),
+    //     Orientation::Landscape(false) => (40, 52),
+    //     Orientation::Landscape(true) => (40, 53),
+    //     Orientation::PortraitInverted(false) => (53, 40),
+    //     Orientation::PortraitInverted(true) => (52, 40),
+    //     Orientation::LandscapeInverted(false) => (40, 53),
+    //     Orientation::LandscapeInverted(true) => (40, 52),
+    // }
 }


### PR DESCRIPTION
The PR adds ILI9341 support. I've marked it as a draft PR because it also uses the unreleased `display-driver-hal` to test it's API. The offset calculation is also disabled at the moement, because I didn't have an appropriate display to test it.

The new `Orientation` type uses a builder like interface:
```rust
let display = Builder::ili9341_rgb565(interface)
    .with_orientation(Orientation::new().rotate(Rotation::Deg270).flip_horizontal())
    .init(&mut delay, Some(display_reset))
    .unwrap();
```
IMO this is easier to use, because you can easily tweak the orientation by adding a `rotate` or `flip_vertical`/`flip_horizontal` commands. Perviously it was only possible to mirror around one axis and the user had to add the necessary rotation manually if they wanted to mirror around the other axis.