### PR TITLE
Add ILI9341 model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
- - added `ModelOptions::invert_colors` flag
- - added `Builder::with_invert_colors(bool)` method
+- added `ModelOptions::invert_colors` flag
+- added `Builder::with_invert_colors(bool)` method
+- added `ILI9341` model support
 
 ### Changed
 
- - `Model::init` changed to expect `options: &ModelOptions`
+- `Model::init` changed to expect `options: &ModelOptions`
 
 ### Removed
 
- - removed duplicated `INVON` call in `ST7735s` model init
+- removed duplicated `INVON` call in `ST7735s` model init
 
 ## [v0.5.0] - 2022-10-19
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Variants that require different screen sizes and window addressing offsets are n
 * ST7789
 * ST7735
 * ILI9486
+* ILI9341
 * ILI9342C
 
 ## Migration

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 // associated re-typing not supported in rust yet
 #![allow(clippy::type_complexity)]
 
-//! This crate provides a generic ddisplay driver to connect to TFT displays
+//! This crate provides a generic display driver to connect to TFT displays
 //! that implement the [MIPI DSI](https://www.mipi.org/specifications/dsi).
 //! Currently only supports SPI with DC pin setups via the [display_interface]
 //!
@@ -13,6 +13,7 @@
 //! * ST7789
 //! * ST7735
 //! * ILI9486
+//! * ILI9341
 //! * ILI9342C
 //!
 //! ## Example

--- a/src/models.rs
+++ b/src/models.rs
@@ -4,11 +4,14 @@ use embedded_graphics_core::prelude::RgbColor;
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 // existing model implementations
+mod ili9341;
 mod ili9342c;
+mod ili934x;
 mod ili9486;
 mod st7735s;
 mod st7789;
 
+pub use ili9341::*;
 pub use ili9342c::*;
 pub use ili9486::*;
 pub use st7735s::*;

--- a/src/models/ili9341.rs
+++ b/src/models/ili9341.rs
@@ -9,17 +9,17 @@ use crate::{
     Builder, Error, ModelOptions,
 };
 
-/// ILI9342C display with Reset pin
+/// ILI9341 display with Reset pin
 /// in Rgb565 color mode
 /// Backlight pin is not controlled
-pub struct ILI9342CRgb565;
+pub struct ILI9341Rgb565;
 
-/// ILI9342C display with Reset pin
+/// ILI9341 display with Reset pin
 /// in Rgb666 color mode
 /// Backlight pin is not controlled
-pub struct ILI9342CRgb666;
+pub struct ILI9341Rgb666;
 
-impl Model for ILI9342CRgb565 {
+impl Model for ILI9341Rgb565 {
     type ColorFormat = Rgb565;
 
     fn init<RST, DELAY, DI>(
@@ -51,11 +51,11 @@ impl Model for ILI9342CRgb565 {
     }
 
     fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((320, 240), (320, 240))
+        ModelOptions::with_sizes((240, 320), (240, 320))
     }
 }
 
-impl Model for ILI9342CRgb666 {
+impl Model for ILI9341Rgb666 {
     type ColorFormat = Rgb666;
 
     fn init<RST, DELAY, DI>(
@@ -87,43 +87,43 @@ impl Model for ILI9342CRgb666 {
     }
 
     fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((320, 240), (320, 240))
+        ModelOptions::with_sizes((240, 320), (240, 320))
     }
 }
 
 // simplified constructor for Display
 
-impl<DI> Builder<DI, ILI9342CRgb565>
+impl<DI> Builder<DI, ILI9341Rgb565>
 where
     DI: WriteOnlyDataCommand,
 {
     ///
-    /// Creates a new [Display] instance with [ILI9342C] as the [Model]
-    /// with the default framebuffer size and display size of 320x240
-    /// *WARNING* Rgb565 only works on non-SPI setups with the ILI9342C!
+    /// Creates a new [Display] instance with [ILI9341] as the [Model]
+    /// with the default framebuffer size and display size of 240x320
+    /// *WARNING* Rgb565 only works on non-SPI setups with the ILI9341!
     ///
     /// # Arguments
     ///
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
     ///
-    pub fn ili9342c_rgb565(di: DI) -> Self {
-        Self::with_model(di, ILI9342CRgb565)
+    pub fn ili9341_rgb565(di: DI) -> Self {
+        Self::with_model(di, ILI9341Rgb565)
     }
 }
 
-impl<DI> Builder<DI, ILI9342CRgb666>
+impl<DI> Builder<DI, ILI9341Rgb666>
 where
     DI: WriteOnlyDataCommand,
 {
     ///
-    /// Creates a new [Display] instance with [ILI9342C] as the [Model]
+    /// Creates a new [Display] instance with [ILI9341] as the [Model]
     /// with the default framebuffer size and display size of 320x240
     ///
     /// # Arguments
     ///
     /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
     ///
-    pub fn ili9342c_rgb666(di: DI) -> Self {
-        Self::with_model(di, ILI9342CRgb666)
+    pub fn ili9341_rgb666(di: DI) -> Self {
+        Self::with_model(di, ILI9341Rgb666)
     }
 }

--- a/src/models/ili934x.rs
+++ b/src/models/ili934x.rs
@@ -1,0 +1,94 @@
+use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
+use embedded_graphics_core::pixelcolor::{IntoStorage, Rgb565, Rgb666, RgbColor};
+use embedded_hal::blocking::delay::DelayUs;
+
+use crate::{instruction::Instruction, models::write_command, Error, ModelOptions};
+
+/// Common init for all ILI934x controllers and color formats.
+fn init_common<DELAY, DI>(
+    di: &mut DI,
+    delay: &mut DELAY,
+    options: &ModelOptions,
+) -> Result<u8, Error>
+where
+    DELAY: DelayUs<u32>,
+    DI: WriteOnlyDataCommand,
+{
+    let madctl = options.madctl();
+
+    write_command(di, Instruction::SLPOUT, &[])?; // turn off sleep
+    write_command(di, Instruction::MADCTL, &[madctl])?; // left -> right, bottom -> top RGB
+    write_command(di, Instruction::INVCO, &[0x0])?; //Inversion Control [00]
+    write_command(di, options.invert_command(), &[])?; // set color inversion
+
+    write_command(di, Instruction::NORON, &[])?; // turn to normal mode
+    write_command(di, Instruction::DISPON, &[])?; // turn on display
+
+    // DISPON requires some time otherwise we risk SPI data issues
+    delay.delay_us(120_000);
+
+    Ok(madctl)
+}
+
+/// Common init for all ILI934x controllers with RGB565 color format.
+pub fn init_rgb565<DELAY, DI>(
+    di: &mut DI,
+    delay: &mut DELAY,
+    options: &ModelOptions,
+) -> Result<u8, DisplayError>
+where
+    DELAY: DelayUs<u32>,
+    DI: WriteOnlyDataCommand,
+{
+    delay.delay_us(120_000);
+
+    write_command(di, Instruction::COLMOD, &[0b0101_0101])?; // 16bit 65k colors
+
+    Ok(init_common(di, delay, options)?)
+}
+
+/// Common init for all ILI934x controllers with RGB666 color format.
+pub fn init_rgb666<DELAY, DI>(
+    di: &mut DI,
+    delay: &mut DELAY,
+    options: &ModelOptions,
+) -> Result<u8, DisplayError>
+where
+    DELAY: DelayUs<u32>,
+    DI: WriteOnlyDataCommand,
+{
+    delay.delay_us(120_000);
+
+    write_command(di, Instruction::COLMOD, &[0b0110_0110])?; // 18bit 262k colors
+
+    Ok(init_common(di, delay, options)?)
+}
+
+pub fn write_pixels_rgb565<DI, I>(di: &mut DI, colors: I) -> Result<(), Error>
+where
+    DI: WriteOnlyDataCommand,
+    I: IntoIterator<Item = Rgb565>,
+{
+    write_command(di, Instruction::RAMWR, &[])?;
+    let mut iter = colors.into_iter().map(|c| c.into_storage());
+
+    let buf = DataFormat::U16BEIter(&mut iter);
+    di.send_data(buf)
+}
+
+pub fn write_pixels_rgb666<DI, I>(di: &mut DI, colors: I) -> Result<(), Error>
+where
+    DI: WriteOnlyDataCommand,
+    I: IntoIterator<Item = Rgb666>,
+{
+    write_command(di, Instruction::RAMWR, &[])?;
+    let mut iter = colors.into_iter().flat_map(|c| {
+        let red = c.r() << 2;
+        let green = c.g() << 2;
+        let blue = c.b() << 2;
+        [red, green, blue]
+    });
+
+    let buf = DataFormat::U8Iter(&mut iter);
+    di.send_data(buf)
+}


### PR DESCRIPTION
This PR adds the ILI9341 model, that was previously added as part of #39. I've cleaned up the code some more and extracted the common code for the `ILI3941` and `ILI9342C` controllers into a separate module.

~~One remaining issue is the color order: Before #36 the RGB/BGR bit for the ILI9342C was inverted. According to the datasheet this shouldn't be necessary, but without the inversion I get incorrect colors on my display. I'm not sure if the datasheet is wrong or what is going on, but I've checked that my display is indeed using the RGB subpixel order by using a magnifying glass.~~