### PR TITLE
add `Builder::with_window_offset_handler` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- added `Builder::with_window_offset_handler` method
 - added `ModelOptions::invert_colors` flag
 - added `Builder::with_invert_colors(bool)` method
 - added `ILI9341` model support

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -101,6 +101,17 @@ where
     }
 
     ///
+    /// Sets the window offset handler
+    ///
+    pub fn with_window_offset_handler(
+        mut self,
+        window_offset_handler: fn(_: &ModelOptions) -> (u16, u16),
+    ) -> Self {
+        self.options.window_offset_handler = window_offset_handler;
+        self
+    }
+
+    ///
     /// Consumes the builder to create a new [Display] with an optional reset [OutputPin].
     /// Blocks using the provided [DelayUs] `delay_source` to perform the display initialization.
     /// ### WARNING


### PR DESCRIPTION
`ModelOptions` has a field for storing an offset handler, but it's currently not accessible unless you provide a custom `Model` implementation to override `Model::default_options`. This addition allows you to set the offset handler via the `Builder`.