### PR TITLE
Documentation improvements

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Builder for [Display] instances.
-/// 
+///
 /// Exposes all possible display options.
 pub struct Builder<DI, MODEL>
 where

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -8,10 +8,9 @@ use crate::{
     Orientation, RefreshOrder,
 };
 
-///
-/// Constructor helper for creating [Display] instances
-/// Exposes all possible display options
-///
+/// Builder for [Display] instances.
+/// 
+/// Exposes all possible display options.
 pub struct Builder<DI, MODEL>
 where
     DI: WriteOnlyDataCommand,

--- a/src/dcs.rs
+++ b/src/dcs.rs
@@ -1,3 +1,5 @@
+//! MIPI DCS commands.
+
 use display_interface::{DataFormat, WriteOnlyDataCommand};
 
 use crate::Error;
@@ -22,26 +24,28 @@ pub use set_tearing_effect::*;
 mod set_invert_mode;
 pub use set_invert_mode::*;
 
+/// Common trait for DCS commands.
 ///
-/// Provides a constructor for DCS commands
-/// e.g. `Madctl::new().with_bgr(true).bytes()`
-///
+/// The methods in this traits are used to convert a DCS command into bytes.
 pub trait DcsCommand {
+    /// Returns the instruction code.
     fn instruction(&self) -> u8;
+
+    /// Fills the given buffer with the command parameters.
     fn fill_params_buf(&self, buffer: &mut [u8]) -> Result<usize, Error>;
 }
 
+/// Wrapper around [`WriteOnlyDataCommand`] with support for writing DCS commands.
 ///
-/// Representation of the MIPI Display Command Set
-/// Allows calling commands as methods with builder pattern
-/// for the more complicated ones. Any command can be executed directly using the [Dcs::write_command] method.
-/// Raw instructions can be sent using [Dcs::write_instruction].
-/// Display interface can be accessed directly for data transfers using the `di` public field.
+/// Commands which are part of the manufacturer independent user command set can be sent to the
+/// display by using the [`write_command`](Self::write_command) method with one of the command types
+/// in this module.
 ///
+/// All other commands, which do not have an associated type in this module, can be sent using
+/// the [`write_raw`](Self::write_raw) method. The underlying display interface is also accessible
+/// using the public [`di`](Self::di) field.
 pub struct Dcs<DI> {
-    ///
-    /// Display interface instance
-    ///
+    /// Display interface instance.
     pub di: DI,
 }
 
@@ -49,33 +53,32 @@ impl<DI> Dcs<DI>
 where
     DI: WriteOnlyDataCommand,
 {
-    ///
-    /// Create new [Dcs] instance using a [WriteOnlyDataCommand]
-    ///
+    /// Creates a new [Dcs] instance from a display interface.
     pub fn write_only(di: DI) -> Self {
         Self { di }
     }
 
-    ///
-    /// Release the Display Interface back
-    ///
+    /// Releases the display interface.
     pub fn release(self) -> DI {
         self.di
     }
 
-    ///
-    /// Writes the specified DCS command "write only" using the provided display interface.
-    ///
+    /// Sends a DCS command to the display interface.
     pub fn write_command(&mut self, command: impl DcsCommand) -> Result<(), Error> {
         let mut param_bytes: [u8; 16] = [0; 16];
         let n = command.fill_params_buf(&mut param_bytes)?;
         self.write_raw(command.instruction(), &param_bytes[..n])
     }
 
-    ///
-    /// Writes the specified DCS instruction and &[u8] parameters "write only"
-    /// using the provided display interface. Use of `write_command` is preferred.
-    ///
+    /// Sends a raw command with the given `instruction` to the display interface.
+    /// 
+    /// The `param_bytes` slice can contain the instruction parameters, which are sent as data after
+    /// the instruction code was sent. If no parameters are required an empty slice can be passed to
+    /// this method.
+    /// 
+    /// This method is intended to be used for sending commands which are not part of the MIPI DCS
+    /// user command set. Use [`write_command`](Self::write_command) for commands in the user
+    /// command set.
     pub fn write_raw(&mut self, instruction: u8, param_bytes: &[u8]) -> Result<(), Error> {
         self.di.send_commands(DataFormat::U8(&[instruction]))?;
 

--- a/src/dcs.rs
+++ b/src/dcs.rs
@@ -71,11 +71,11 @@ where
     }
 
     /// Sends a raw command with the given `instruction` to the display interface.
-    /// 
+    ///
     /// The `param_bytes` slice can contain the instruction parameters, which are sent as data after
     /// the instruction code was sent. If no parameters are required an empty slice can be passed to
     /// this method.
-    /// 
+    ///
     /// This method is intended to be used for sending commands which are not part of the MIPI DCS
     /// user command set. Use [`write_command`](Self::write_command) for commands in the user
     /// command set.

--- a/src/dcs/set_address_mode.rs
+++ b/src/dcs/set_address_mode.rs
@@ -7,10 +7,12 @@ use crate::{
 
 use super::DcsCommand;
 
+/// Set Address Mode
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct SetAddressMode(u8);
 
 impl SetAddressMode {
+    /// Creates a new Set Address Mode command.
     pub fn new(
         color_order: ColorOrder,
         orientation: Orientation,

--- a/src/dcs/set_column_address.rs
+++ b/src/dcs/set_column_address.rs
@@ -4,6 +4,7 @@ use crate::Error;
 
 use super::DcsCommand;
 
+/// Set Column Address
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetColumnAddress {
     start_column: u16,
@@ -11,9 +12,7 @@ pub struct SetColumnAddress {
 }
 
 impl SetColumnAddress {
-    ///
-    /// Construct a new Caset range
-    ///
+    /// Creates a new Set Column Address command.
     pub fn new(start_column: u16, end_column: u16) -> Self {
         Self {
             start_column,

--- a/src/dcs/set_invert_mode.rs
+++ b/src/dcs/set_invert_mode.rs
@@ -2,6 +2,7 @@ use crate::{ColorInversion, Error};
 
 use super::DcsCommand;
 
+/// Set Invert Mode
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetInvertMode(pub ColorInversion);
 

--- a/src/dcs/set_page_address.rs
+++ b/src/dcs/set_page_address.rs
@@ -4,6 +4,7 @@ use crate::Error;
 
 use super::DcsCommand;
 
+/// Set Page Address
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetPageAddress {
     start_row: u16,
@@ -11,9 +12,7 @@ pub struct SetPageAddress {
 }
 
 impl SetPageAddress {
-    ///
-    /// Construct a new Raset range
-    ///
+    /// Creates a new Set Page Address command.
     pub fn new(start_row: u16, end_row: u16) -> Self {
         Self { start_row, end_row }
     }

--- a/src/dcs/set_pixel_format.rs
+++ b/src/dcs/set_pixel_format.rs
@@ -4,14 +4,12 @@ use crate::Error;
 
 use super::DcsCommand;
 
+/// Set Pixel Format
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetPixelFormat(PixelFormat);
 
 impl SetPixelFormat {
-    ///
-    /// Set the pixel format that the MCU will be sending to this
-    /// display.
-    ///
+    /// Creates a new Set Pixel Format command.
     pub fn new(pixel_format: PixelFormat) -> Self {
         Self(pixel_format)
     }
@@ -34,11 +32,17 @@ impl DcsCommand for SetPixelFormat {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum BitsPerPixel {
+    /// 3 bits per pixel.
     Three = 0b001,
+    /// 8 bits per pixel.
     Eight = 0b010,
+    /// 12 bits per pixel.
     Twelve = 0b011,
+    /// 16 bits per pixel.
     Sixteen = 0b101,
+    /// 18 bits per pixel.
     Eighteen = 0b110,
+    /// 24 bits per pixel.
     TwentyFour = 0b111,
 }
 

--- a/src/dcs/set_scroll_area.rs
+++ b/src/dcs/set_scroll_area.rs
@@ -4,6 +4,7 @@ use crate::{Error, ModelOptions};
 
 use super::DcsCommand;
 
+/// Set Scroll Area
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetScrollArea {
     tfa: u16,
@@ -12,10 +13,9 @@ pub struct SetScrollArea {
 }
 
 impl SetScrollArea {
-    ///
-    /// Construct a new Vscrdef with TFA, VSA and BFA sizes.
+    /// Creates a new Set Scroll Area command.
+    /// 
     /// VSA should default to the display's height (or width) framebuffer size.
-    ///
     pub fn new(tfa: u16, vsa: u16, bfa: u16) -> Self {
         Self { tfa, vsa, bfa }
     }

--- a/src/dcs/set_scroll_area.rs
+++ b/src/dcs/set_scroll_area.rs
@@ -14,7 +14,7 @@ pub struct SetScrollArea {
 
 impl SetScrollArea {
     /// Creates a new Set Scroll Area command.
-    /// 
+    ///
     /// VSA should default to the display's height (or width) framebuffer size.
     pub fn new(tfa: u16, vsa: u16, bfa: u16) -> Self {
         Self { tfa, vsa, bfa }

--- a/src/dcs/set_scroll_start.rs
+++ b/src/dcs/set_scroll_start.rs
@@ -4,13 +4,12 @@ use crate::Error;
 
 use super::DcsCommand;
 
+/// Set Scroll Start
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetScrollStart(u16);
 
 impl SetScrollStart {
-    ///
-    /// Construct a new Vscad given offset
-    ///
+    /// Creates a new Set Scroll Start command.
     pub fn new(offset: u16) -> Self {
         Self(offset)
     }

--- a/src/dcs/set_tearing_effect.rs
+++ b/src/dcs/set_tearing_effect.rs
@@ -2,6 +2,7 @@ use crate::{Error, TearingEffect};
 
 use super::DcsCommand;
 
+/// Set Tearing Effect
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetTearingEffect(pub TearingEffect);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,13 +2,12 @@
 
 use display_interface::DisplayError;
 
-///
-/// An error holding its source [embedded_hal::digital::v2::OutputPin::Error]
-/// or [display_interface::DisplayError]
-///
+/// Error returned by [`Builder::init`](crate::Builder).
 #[derive(Debug)]
 pub enum InitError<PE> {
+    /// Error caused by the display interface.
     DisplayError,
+    /// Error caused by the reset pin's [`OutputPin`](embedded_hal::digital::v2::OutputPin) implementation.
     Pin(PE),
 }
 

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -116,7 +116,8 @@ where
 }
 
 impl BitsPerPixel {
-    pub const fn from_rgbcolor<C: RgbColor>() -> Self {
+    /// Returns the bits per pixel for a embedded-graphics [`RgbColor`].
+    pub const fn from_rgb_color<C: RgbColor>() -> Self {
         let bpp = C::MAX_R.trailing_ones() + C::MAX_G.trailing_ones() + C::MAX_B.trailing_ones();
 
         match bpp {
@@ -137,24 +138,24 @@ mod test {
     use embedded_graphics_core::pixelcolor::*;
 
     #[test]
-    fn bpp_from_rgbcolor_works() {
+    fn bpp_from_rgb_color_works() {
         assert_eq!(
-            BitsPerPixel::from_rgbcolor::<Rgb565>(),
+            BitsPerPixel::from_rgb_color::<Rgb565>(),
             BitsPerPixel::Sixteen
         );
         assert_eq!(
-            BitsPerPixel::from_rgbcolor::<Rgb666>(),
+            BitsPerPixel::from_rgb_color::<Rgb666>(),
             BitsPerPixel::Eighteen
         );
         assert_eq!(
-            BitsPerPixel::from_rgbcolor::<Rgb888>(),
+            BitsPerPixel::from_rgb_color::<Rgb888>(),
             BitsPerPixel::TwentyFour
         );
     }
 
     #[test]
     #[should_panic]
-    fn bpp_from_rgbcolor_invalid_panics() {
-        BitsPerPixel::from_rgbcolor::<Rgb555>();
+    fn bpp_from_rgb_color_invalid_panics() {
+        BitsPerPixel::from_rgb_color::<Rgb555>();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 // associated re-typing not supported in rust yet
 #![allow(clippy::type_complexity)]
+#![warn(missing_docs)]
 
 //! This crate provides a generic display driver to connect to TFT displays
 //! that implement the [MIPI DSI](https://www.mipi.org/specifications/dsi).
@@ -36,7 +37,7 @@ pub use error::Error;
 pub mod options;
 pub use options::*;
 
-pub mod builder;
+mod builder;
 pub use builder::Builder;
 
 pub mod dcs;

--- a/src/models.rs
+++ b/src/models.rs
@@ -60,7 +60,7 @@ pub trait Model {
     }
 
     /// Writes pixels to the display IC via the given display interface.
-    /// 
+    ///
     /// Any pixel color format conversion is done here.
     fn write_pixels<DI, I>(&mut self, di: &mut Dcs<DI>, colors: I) -> Result<(), Error>
     where
@@ -68,7 +68,7 @@ pub trait Model {
         I: IntoIterator<Item = Self::ColorFormat>;
 
     /// Creates default [ModelOptions] for this particular [Model].
-    /// 
+    ///
     /// This serves as a "sane default". There can be additional variants which will be provided via
     /// helper constructors.
     fn default_options() -> ModelOptions;

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,3 +1,5 @@
+//! Display models.
+
 use crate::{
     dcs::{Dcs, SetAddressMode},
     error::InitError,
@@ -21,7 +23,9 @@ pub use ili9486::*;
 pub use st7735s::*;
 pub use st7789::*;
 
+/// Display model.
 pub trait Model {
+    /// The color format.
     type ColorFormat: RgbColor;
 
     /// Initializes the display for this model with MADCTL from [crate::Display]
@@ -38,6 +42,7 @@ pub trait Model {
         DELAY: DelayUs<u32>,
         DI: WriteOnlyDataCommand;
 
+    /// Resets the display using a reset pin.
     fn hard_reset<RST, DELAY>(
         &mut self,
         rst: &mut RST,
@@ -54,17 +59,17 @@ pub trait Model {
         Ok(())
     }
 
-    /// Writes pixels to the display IC via the given DisplayInterface
-    /// Any pixel color format conversion is done here
+    /// Writes pixels to the display IC via the given display interface.
+    /// 
+    /// Any pixel color format conversion is done here.
     fn write_pixels<DI, I>(&mut self, di: &mut Dcs<DI>, colors: I) -> Result<(), Error>
     where
         DI: WriteOnlyDataCommand,
         I: IntoIterator<Item = Self::ColorFormat>;
 
-    ///
-    /// Creates default [ModelOptions] for this particular [Model]. This serves
-    /// as a "sane default". There can be additional variants which will be provided via
+    /// Creates default [ModelOptions] for this particular [Model].
+    /// 
+    /// This serves as a "sane default". There can be additional variants which will be provided via
     /// helper constructors.
-    ///
     fn default_options() -> ModelOptions;
 }

--- a/src/models/ili9341.rs
+++ b/src/models/ili9341.rs
@@ -96,11 +96,11 @@ where
     DI: WriteOnlyDataCommand,
 {
     /// Creates a new display builder for an ILI9341 display in Rgb565 color mode.
-    /// 
+    ///
     /// The default framebuffer size and display size is 240x320 pixels.
-    /// 
+    ///
     /// # Limitations
-    /// 
+    ///
     /// The Rgb565 color mode is not supported for displays with SPI connection.
     ///
     /// # Arguments
@@ -117,7 +117,7 @@ where
     DI: WriteOnlyDataCommand,
 {
     /// Creates a new display builder for an ILI9341 display in Rgb565 color mode.
-    /// 
+    ///
     /// The default framebuffer size and display size is 240x320 pixels.
     ///
     /// # Arguments

--- a/src/models/ili9341.rs
+++ b/src/models/ili9341.rs
@@ -9,14 +9,10 @@ use crate::{
     Builder, Error, ModelOptions,
 };
 
-/// ILI9341 display with Reset pin
-/// in Rgb565 color mode
-/// Backlight pin is not controlled
+/// ILI9341 display in Rgb565 color mode.
 pub struct ILI9341Rgb565;
 
-/// ILI9341 display with Reset pin
-/// in Rgb666 color mode
-/// Backlight pin is not controlled
+/// ILI9341 display in Rgb666 color mode.
 pub struct ILI9341Rgb666;
 
 impl Model for ILI9341Rgb565 {
@@ -39,7 +35,7 @@ impl Model for ILI9341Rgb565 {
             None => dcs.write_command(SoftReset)?,
         }
 
-        let pf = PixelFormat::with_all(BitsPerPixel::from_rgbcolor::<Self::ColorFormat>());
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
         ili934x::init_common(dcs, delay, options, pf).map_err(Into::into)
     }
 
@@ -76,7 +72,7 @@ impl Model for ILI9341Rgb666 {
             None => dcs.write_command(SoftReset)?,
         }
 
-        let pf = PixelFormat::with_all(BitsPerPixel::from_rgbcolor::<Self::ColorFormat>());
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
         ili934x::init_common(dcs, delay, options, pf).map_err(Into::into)
     }
 
@@ -99,14 +95,17 @@ impl<DI> Builder<DI, ILI9341Rgb565>
 where
     DI: WriteOnlyDataCommand,
 {
-    ///
-    /// Creates a new [Display] instance with [ILI9341] as the [Model]
-    /// with the default framebuffer size and display size of 240x320
-    /// *WARNING* Rgb565 only works on non-SPI setups with the ILI9341!
+    /// Creates a new display builder for an ILI9341 display in Rgb565 color mode.
+    /// 
+    /// The default framebuffer size and display size is 240x320 pixels.
+    /// 
+    /// # Limitations
+    /// 
+    /// The Rgb565 color mode is not supported for displays with SPI connection.
     ///
     /// # Arguments
     ///
-    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `di` - a [display interface](WriteOnlyDataCommand) for communicating with the display
     ///
     pub fn ili9341_rgb565(di: DI) -> Self {
         Self::with_model(di, ILI9341Rgb565)
@@ -117,13 +116,13 @@ impl<DI> Builder<DI, ILI9341Rgb666>
 where
     DI: WriteOnlyDataCommand,
 {
-    ///
-    /// Creates a new [Display] instance with [ILI9341] as the [Model]
-    /// with the default framebuffer size and display size of 320x240
+    /// Creates a new display builder for an ILI9341 display in Rgb565 color mode.
+    /// 
+    /// The default framebuffer size and display size is 240x320 pixels.
     ///
     /// # Arguments
     ///
-    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `di` - a [display interface](WriteOnlyDataCommand) for communicating with the display
     ///
     pub fn ili9341_rgb666(di: DI) -> Self {
         Self::with_model(di, ILI9341Rgb666)

--- a/src/models/ili9342c.rs
+++ b/src/models/ili9342c.rs
@@ -96,11 +96,11 @@ where
     DI: WriteOnlyDataCommand,
 {
     /// Creates a new display builder for an ILI9342C display in Rgb565 color mode.
-    /// 
+    ///
     /// The default framebuffer size and display size is 320x240 pixels.
-    /// 
+    ///
     /// # Limitations
-    /// 
+    ///
     /// The Rgb565 color mode is not supported for displays with SPI connection.
     ///
     /// # Arguments
@@ -117,7 +117,7 @@ where
     DI: WriteOnlyDataCommand,
 {
     /// Creates a new display builder for an ILI9342C display in Rgb666 color mode.
-    /// 
+    ///
     /// The default framebuffer size and display size is 320x240
     ///
     /// # Arguments

--- a/src/models/ili9342c.rs
+++ b/src/models/ili9342c.rs
@@ -9,14 +9,10 @@ use crate::{
     Builder, Error, ModelOptions,
 };
 
-/// ILI9342C display with Reset pin
-/// in Rgb565 color mode
-/// Backlight pin is not controlled
+/// ILI9342C display in Rgb565 color mode.
 pub struct ILI9342CRgb565;
 
-/// ILI9342C display with Reset pin
-/// in Rgb666 color mode
-/// Backlight pin is not controlled
+/// ILI9342C display in Rgb666 color mode.
 pub struct ILI9342CRgb666;
 
 impl Model for ILI9342CRgb565 {
@@ -39,7 +35,7 @@ impl Model for ILI9342CRgb565 {
             None => dcs.write_command(SoftReset)?,
         }
 
-        let pf = PixelFormat::with_all(BitsPerPixel::from_rgbcolor::<Self::ColorFormat>());
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
         ili934x::init_common(dcs, delay, options, pf).map_err(Into::into)
     }
 
@@ -76,7 +72,7 @@ impl Model for ILI9342CRgb666 {
             None => dcs.write_command(SoftReset)?,
         }
 
-        let pf = PixelFormat::with_all(BitsPerPixel::from_rgbcolor::<Self::ColorFormat>());
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
         ili934x::init_common(dcs, delay, options, pf).map_err(Into::into)
     }
 
@@ -99,14 +95,17 @@ impl<DI> Builder<DI, ILI9342CRgb565>
 where
     DI: WriteOnlyDataCommand,
 {
-    ///
-    /// Creates a new [Display] instance with [ILI9342C] as the [Model]
-    /// with the default framebuffer size and display size of 320x240
-    /// *WARNING* Rgb565 only works on non-SPI setups with the ILI9342C!
+    /// Creates a new display builder for an ILI9342C display in Rgb565 color mode.
+    /// 
+    /// The default framebuffer size and display size is 320x240 pixels.
+    /// 
+    /// # Limitations
+    /// 
+    /// The Rgb565 color mode is not supported for displays with SPI connection.
     ///
     /// # Arguments
     ///
-    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `di` - a [display interface](WriteOnlyDataCommand) for communicating with the display
     ///
     pub fn ili9342c_rgb565(di: DI) -> Self {
         Self::with_model(di, ILI9342CRgb565)
@@ -117,13 +116,13 @@ impl<DI> Builder<DI, ILI9342CRgb666>
 where
     DI: WriteOnlyDataCommand,
 {
-    ///
-    /// Creates a new [Display] instance with [ILI9342C] as the [Model]
-    /// with the default framebuffer size and display size of 320x240
+    /// Creates a new display builder for an ILI9342C display in Rgb666 color mode.
+    /// 
+    /// The default framebuffer size and display size is 320x240
     ///
     /// # Arguments
     ///
-    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `di` - a [display interface](WriteOnlyDataCommand) for communicating with the display
     ///
     pub fn ili9342c_rgb666(di: DI) -> Self {
         Self::with_model(di, ILI9342CRgb666)

--- a/src/models/ili9486.rs
+++ b/src/models/ili9486.rs
@@ -119,11 +119,11 @@ where
     DI: WriteOnlyDataCommand,
 {
     /// Creates a new display builder for an ILI9486 display in Rgb565 color mode.
-    /// 
+    ///
     /// The default framebuffer size and display size is 320x480 pixels.
-    /// 
+    ///
     /// # Limitations
-    /// 
+    ///
     /// The Rgb565 color mode is not supported for displays with SPI connection.
     ///
     /// # Arguments
@@ -140,7 +140,7 @@ where
     DI: WriteOnlyDataCommand,
 {
     /// Creates a new display builder for ILI9486 displays in Rgb666 color mode.
-    /// 
+    ///
     /// The default framebuffer size and display size is 320x480 pixels.
     ///
     /// # Arguments

--- a/src/models/ili9486.rs
+++ b/src/models/ili9486.rs
@@ -16,12 +16,10 @@ use crate::{
 
 use super::Model;
 
-/// ILI9486 display in Rgb565 color mode (does *NOT* work with SPI)
-/// Backlight pin is not controlled
+/// ILI9486 display in Rgb565 color mode.
 pub struct ILI9486Rgb565;
 
-/// ILI9486 display in Rgb666 color mode (works with SPI)
-/// Backlight pin is not controlled
+/// ILI9486 display in Rgb666 color mode.
 pub struct ILI9486Rgb666;
 
 impl Model for ILI9486Rgb565 {
@@ -45,7 +43,7 @@ impl Model for ILI9486Rgb565 {
         }
         delay.delay_us(120_000);
 
-        let pf = PixelFormat::with_all(BitsPerPixel::from_rgbcolor::<Self::ColorFormat>());
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
         Ok(init_common(dcs, delay, options, pf)?)
     }
 
@@ -88,7 +86,7 @@ impl Model for ILI9486Rgb666 {
 
         delay.delay_us(120_000);
 
-        let pf = PixelFormat::with_all(BitsPerPixel::from_rgbcolor::<Self::ColorFormat>());
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
         Ok(init_common(dcs, delay, options, pf)?)
     }
 
@@ -120,14 +118,17 @@ impl<DI> Builder<DI, ILI9486Rgb565>
 where
     DI: WriteOnlyDataCommand,
 {
-    ///
-    /// Creates a new [Display] instance with [ILI9486] as the [Model]
-    /// with the default framebuffer size and display size of 320x480
-    /// *WARNING* Rgb565 only works on non-SPI setups with the ILI9486!
+    /// Creates a new display builder for an ILI9486 display in Rgb565 color mode.
+    /// 
+    /// The default framebuffer size and display size is 320x480 pixels.
+    /// 
+    /// # Limitations
+    /// 
+    /// The Rgb565 color mode is not supported for displays with SPI connection.
     ///
     /// # Arguments
     ///
-    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `di` - a [display interface](WriteOnlyDataCommand) for communicating with the display
     ///
     pub fn ili9486_rgb565(di: DI) -> Self {
         Self::with_model(di, ILI9486Rgb565)
@@ -138,13 +139,13 @@ impl<DI> Builder<DI, ILI9486Rgb666>
 where
     DI: WriteOnlyDataCommand,
 {
-    ///
-    /// Creates a new [Display] instance with [ILI9486] as the [Model]
-    /// with the default framebuffer size and display size of 320x480
+    /// Creates a new display builder for ILI9486 displays in Rgb666 color mode.
+    /// 
+    /// The default framebuffer size and display size is 320x480 pixels.
     ///
     /// # Arguments
     ///
-    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `di` - a [display interface](WriteOnlyDataCommand) for communicating with the display
     ///
     pub fn ili9486_rgb666(di: DI) -> Self {
         Self::with_model(di, ILI9486Rgb666)

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -13,8 +13,7 @@ use crate::{
 
 use super::{Dcs, Model};
 
-/// ST7735s SPI display with Reset pin
-/// Only SPI with DC pin interface is supported
+/// ST7735s display in Rgb565 color mode.
 pub struct ST7735s;
 
 impl Model for ST7735s {
@@ -69,7 +68,7 @@ impl Model for ST7735s {
             ],
         )?; // set GAMMA -Polarity characteristics
 
-        let pf = PixelFormat::with_all(BitsPerPixel::from_rgbcolor::<Self::ColorFormat>());
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
         dcs.write_command(SetPixelFormat::new(pf))?; // set interface pixel format, 16bit pixel into frame memory
 
         dcs.write_command(madctl)?; // set memory data access control, Top -> Bottom, RGB, Left -> Right
@@ -92,7 +91,10 @@ impl Model for ST7735s {
     }
 
     fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((80, 160), (132, 162)).with_invert_colors(ColorInversion::Inverted)
+        let mut options = ModelOptions::with_sizes((80, 160), (132, 162));
+        options.set_invert_colors(ColorInversion::Inverted);
+
+        options
     }
 }
 
@@ -102,15 +104,13 @@ impl<DI> Builder<DI, ST7735s>
 where
     DI: WriteOnlyDataCommand,
 {
+    /// Creates a new display builder for ST7735s displays in Rgb565 color mode.
     ///
-    /// Creates a new [Display] instance with [ST7735s] as the [Model] with a
-    /// hard reset Pin with the default framebuffer size of 132x162
-    /// and display size of 80x160
+    /// The default framebuffer size is 132x162 pixels and display size is 80x160 pixels.
     ///
     /// # Arguments
     ///
-    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
-    /// * `options` - the [DisplayOptions] for this display/model
+    /// * `di` - a [display interface](WriteOnlyDataCommand) for communicating with the display
     ///
     pub fn st7735s(di: DI) -> Self {
         Self::with_model(di, ST7735s)

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -13,10 +13,11 @@ use crate::{
 
 use super::Model;
 
-/// Module containing all ST7789 variants and helper constructors for [Display]
+/// Module containing all ST7789 variants.
 mod variants;
 
-/// ST7789 SPI display with Reset pin
+/// ST7789 display in Rgb565 color mode.
+/// 
 /// Only SPI with DC pin interface is supported
 pub struct ST7789;
 
@@ -52,7 +53,7 @@ impl Model for ST7789 {
 
         dcs.write_command(SetInvertMode(options.invert_colors))?;
 
-        let pf = PixelFormat::with_all(BitsPerPixel::from_rgbcolor::<Self::ColorFormat>());
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
         dcs.write_command(SetPixelFormat::new(pf))?;
         delay.delay_us(10_000);
         dcs.write_command(EnterNormalMode)?;
@@ -80,7 +81,9 @@ impl Model for ST7789 {
     }
 
     fn default_options() -> crate::ModelOptions {
-        ModelOptions::with_sizes((240, 320), (240, 320))
-            .with_invert_colors(ColorInversion::Inverted)
+        let mut options = ModelOptions::with_sizes((240, 320), (240, 320));
+        options.set_invert_colors(ColorInversion::Normal);
+
+        return options;
     }
 }

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -17,7 +17,7 @@ use super::Model;
 mod variants;
 
 /// ST7789 display in Rgb565 color mode.
-/// 
+///
 /// Only SPI with DC pin interface is supported
 pub struct ST7789;
 

--- a/src/models/st7789/variants.rs
+++ b/src/models/st7789/variants.rs
@@ -8,34 +8,33 @@ impl<DI> Builder<DI, ST7789>
 where
     DI: WriteOnlyDataCommand,
 {
+    /// Creates a new display builder for a ST7789 display in Rgb565 color mode.
     ///
-    /// Creates a new [Display] instance with [ST7789] as the [super::Model] with
-    /// general variant using display framebuffer size of 240x320
+    /// The default framebuffer size and display size is 240x320 pixels.
     ///
     /// # Arguments
     ///
-    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `di` - a [display interface](WriteOnlyDataCommand) for communicating with the display
     ///
     pub fn st7789(di: DI) -> Self {
         Self::with_model(di, ST7789)
     }
 
+    /// Creates a new display builder for the pico1 variant of a ST7789 display in Rgb565 color
+    /// mode.
     ///
-    /// Creates a new [Display] instance with [ST7789] as the [super::Model] with
-    /// pico1 variant using display and framebuffer size of 135x240 and a clipping offset
+    /// The pico1 variant uses a display and framebuffer size of 135x240 and a clipping offset.
     ///
     /// # Arguments
     ///
-    /// * `di` - a [DisplayInterface](WriteOnlyDataCommand) for talking with the display
+    /// * `di` - a [display interface](WriteOnlyDataCommand) for communicating with the display
     ///
     pub fn st7789_pico1(di: DI) -> Self {
+        let mut options = ModelOptions::with_all((135, 240), (135, 240), pico1_offset);
+        options.set_invert_colors(ColorInversion::Inverted);
+
         // pico v1 is cropped to 135x240 size with an offset of (40, 53)
-        Self::new(
-            di,
-            ST7789,
-            ModelOptions::with_all((135, 240), (135, 240), pico1_offset)
-                .with_invert_colors(ColorInversion::Inverted),
-        )
+        Self::new(di, ST7789, options)
     }
 }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,7 +1,7 @@
 //! [ModelOptions] and other helper types.
 
 /// [ModelOptions] holds the settings for [Model](crate::Model)s.
-/// 
+///
 /// `display_size` being set is the minimum requirement.
 #[derive(Clone)]
 pub struct ModelOptions {

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,9 +1,8 @@
-//! Module holding [ModelOptions] and other helper types for [super::Display]
+//! [ModelOptions] and other helper types.
 
-///
-/// [ModelOptions] hold all the various settings that can impact a particular [super::Model]
+/// [ModelOptions] holds the settings for [Model](crate::Model)s.
+/// 
 /// `display_size` being set is the minimum requirement.
-///
 #[derive(Clone)]
 pub struct ModelOptions {
     /// Specify display color ordering
@@ -24,10 +23,9 @@ pub struct ModelOptions {
 }
 
 impl ModelOptions {
+    /// Creates model options for the given display and framebuffer sizes.
     ///
-    /// Constructs a [ModelOptions]
-    /// with given display and framebuffer sizes
-    ///
+    /// All other settings are initialized to their default value.
     pub fn with_sizes(display_size: (u16, u16), framebuffer_size: (u16, u16)) -> Self {
         Self {
             color_order: ColorOrder::default(),
@@ -40,10 +38,7 @@ impl ModelOptions {
         }
     }
 
-    ///
-    /// Constructs a [ModelOptions]
-    /// with given display and framebuffer sizes and provided window offset handler
-    ///
+    /// Creates model options for the given sizes and offset handler.
     pub fn with_all(
         display_size: (u16, u16),
         framebuffer_size: (u16, u16),
@@ -60,24 +55,22 @@ impl ModelOptions {
         }
     }
 
-    pub fn with_invert_colors(mut self, color_inversion: ColorInversion) -> Self {
+    /// Sets the color inversion setting.
+    pub fn set_invert_colors(&mut self, color_inversion: ColorInversion) {
         self.invert_colors = color_inversion;
-        self
     }
 
+    /// Returns the display size based on current orientation and display options.
     ///
-    /// Returns display size based on current orientation and display options.
     /// Used by models.
-    ///
-    pub fn display_size(&self) -> (u16, u16) {
+    pub(crate) fn display_size(&self) -> (u16, u16) {
         Self::orient_size(self.display_size, self.orientation())
     }
 
-    ///
     /// Returns framebuffer size based on current orientation and display options.
-    /// Used by models. Uses display_size if framebuffer_size is not set.
     ///
-    pub fn framebuffer_size(&self) -> (u16, u16) {
+    /// Used by models. Uses display_size if framebuffer_size is not set.
+    pub(crate) fn framebuffer_size(&self) -> (u16, u16) {
         let size = if self.framebuffer_size == (0, 0) {
             self.display_size
         } else {
@@ -87,31 +80,28 @@ impl ModelOptions {
         Self::orient_size(size, self.orientation())
     }
 
+    /// Returns the larger of framebuffer width or height.
     ///
-    /// Returns the larger of framebuffer width or height. Used for scroll
-    /// area setups.
-    ///
-    pub fn framebuffer_size_max(&self) -> u16 {
+    /// Used for scroll area setups.
+    pub(crate) fn framebuffer_size_max(&self) -> u16 {
         let (w, h) = self.framebuffer_size();
 
         w.max(h)
     }
 
-    ///
     /// Returns window offset (x, y) based on current orientation and display options.
-    /// Used by [Display::set_address_window]
     ///
-    pub fn window_offset(&mut self) -> (u16, u16) {
+    /// Used by [Display::set_address_window](crate::Display::set_address_window).
+    pub(crate) fn window_offset(&mut self) -> (u16, u16) {
         (self.window_offset_handler)(self)
     }
 
+    /// Returns the current orientation.
     pub fn orientation(&self) -> Orientation {
         self.orientation
     }
 
-    ///
-    /// Sets the current [Orientation]
-    ///
+    /// Sets the orientation.
     pub fn set_orientation(&mut self, orientation: Orientation) {
         self.orientation = orientation;
     }
@@ -171,24 +161,12 @@ impl Default for Orientation {
     }
 }
 
-impl Orientation {
-    pub fn value_u8(&self) -> u8 {
-        match self {
-            Orientation::Portrait(false) => 0b0000_0000,
-            Orientation::Portrait(true) => 0b0100_0000,
-            Orientation::PortraitInverted(false) => 0b1100_0000,
-            Orientation::PortraitInverted(true) => 0b1000_0000,
-            Orientation::Landscape(false) => 0b0010_0000,
-            Orientation::Landscape(true) => 0b0110_0000,
-            Orientation::LandscapeInverted(false) => 0b1110_0000,
-            Orientation::LandscapeInverted(true) => 0b1010_0000,
-        }
-    }
-}
-
+/// Color inversion.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ColorInversion {
+    /// Normal colors.
     Normal,
+    /// Inverted colors.
     Inverted,
 }
 
@@ -198,9 +176,12 @@ impl Default for ColorInversion {
     }
 }
 
+/// Vertical refresh order.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum VerticalRefreshOrder {
+    /// Refresh from top to bottom.
     TopToBottom,
+    /// Refresh from bottom to top.
     BottomToTop,
 }
 
@@ -211,6 +192,8 @@ impl Default for VerticalRefreshOrder {
 }
 
 impl VerticalRefreshOrder {
+    /// Returns the opposite refresh order.
+    #[must_use]
     pub const fn flip(self) -> Self {
         match self {
             Self::TopToBottom => Self::BottomToTop,
@@ -219,9 +202,12 @@ impl VerticalRefreshOrder {
     }
 }
 
+/// Horizontal refresh order.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum HorizontalRefreshOrder {
+    /// Refresh from left to right.
     LeftToRight,
+    /// Refresh from right to left.
     RightToLeft,
 }
 
@@ -232,6 +218,8 @@ impl Default for HorizontalRefreshOrder {
 }
 
 impl HorizontalRefreshOrder {
+    /// Returns the opposite refresh order.
+    #[must_use]
     pub const fn flip(self) -> Self {
         match self {
             Self::LeftToRight => Self::RightToLeft,
@@ -240,16 +228,19 @@ impl HorizontalRefreshOrder {
     }
 }
 
+/// Display refresh order.
 ///
-/// Display refresh order, defaults to left to right, top to bottom
-///
+/// Defaults to left to right, top to bottom.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct RefreshOrder {
+    /// Vertical refresh order.
     pub vertical: VerticalRefreshOrder,
+    /// Horizontal refresh order.
     pub horizontal: HorizontalRefreshOrder,
 }
 
 impl RefreshOrder {
+    /// Creates a new refresh order.
     pub const fn new(vertical: VerticalRefreshOrder, horizontal: HorizontalRefreshOrder) -> Self {
         Self {
             vertical,
@@ -257,32 +248,26 @@ impl RefreshOrder {
         }
     }
 
+    /// Returns a refresh order with flipped vertical refresh order.
+    #[must_use]
     pub const fn flip_vertical(self) -> Self {
-        let Self {
-            vertical,
-            horizontal,
-        } = self;
         Self {
-            vertical: vertical.flip(),
-            horizontal,
+            vertical: self.vertical.flip(),
+            ..self
         }
     }
 
+    /// Returns a refresh order with flipped horizontal refresh order.
+    #[must_use]
     pub const fn flip_horizontal(self) -> Self {
-        let Self {
-            vertical,
-            horizontal,
-        } = self;
         Self {
-            vertical,
-            horizontal: horizontal.flip(),
+            horizontal: self.horizontal.flip(),
+            ..self
         }
     }
 }
 
-///
 /// Tearing effect output setting.
-///
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum TearingEffect {
     /// Disable output.
@@ -293,12 +278,12 @@ pub enum TearingEffect {
     HorizontalAndVertical,
 }
 
-///
-/// Defines expected color component ordering, RGB or BGR
-///
+/// Subpixel order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ColorOrder {
+    /// RGB subpixel order.
     Rgb,
+    /// BGR subpixel order.
     Bgr,
 }
 


### PR DESCRIPTION
While I was looking at the new code I discovered that some parts of the code weren't documented yet. This PR does at least add some basic documentation to all parts of the code.

I've changed the style of documentation a bit to use the style recommended in the Rust style guide and API guidelines. While the preferred commenting style is subjective there are some objective advantages of using the recommended style. Especially using a summary line (https://doc.rust-lang.org/1.0.0/style/style/comments.html#summary-line) makes the generated docs more readable.