### PR TITLE
Update dependency Embedded Graphics Core to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mipidsi"
 description = "MIPI Display Serial Interface generic driver"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Ales Katona <almindor@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -13,7 +13,7 @@ rust-version = "1.59"
 
 [dependencies]
 display-interface = "0.4.1"
-embedded-graphics-core = "0.3.3"
+embedded-graphics-core = "0.4.0"
 embedded-hal = "0.2.7"
 nb = "1.0.0"
 


### PR DESCRIPTION
There is a new release of Embedded Graphics 0.8.
It's necessary to update the dependency on the core to 0.4.0.