### PR TITLE
Async support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ documentation = "https://docs.rs/mipidsi"
 rust-version = "1.61"
 
 [dependencies]
-display-interface = "0.4.1"
+display-interface = { git = "https://github.com/bugadani/display-interface.git", branch = "async" }
 embedded-graphics-core = "0.4.0"
-embedded-hal = "0.2.7"
+embedded-hal = "1.0.0-alpha.10"
 nb = "1.0.0"
 
 [dependencies.heapless]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,6 @@ optional = true
 version = "0.7.16"
 
 [features]
-default = ["batch", "async"] # TODO: Remove nightly after feature completed
+default = ["batch", "async"] # TODO: Remove async as default after feature completed
 batch = ["heapless"]
 async =  ["display-interface/async", "display-interface/nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,10 @@ documentation = "https://docs.rs/mipidsi"
 rust-version = "1.61"
 
 [dependencies]
-display-interface = { git = "https://github.com/bugadani/display-interface.git", branch = "async" }
+display-interface = { git = "https://github.com/bugadani/display-interface.git", branch = "async"}
 embedded-graphics-core = "0.4.0"
 embedded-hal = "1.0.0-alpha.10"
+embedded-hal-async = "0.2.0-alpha.1"
 nb = "1.0.0"
 
 [dependencies.heapless]
@@ -22,5 +23,6 @@ optional = true
 version = "0.7.16"
 
 [features]
-default = ["batch"]
+default = ["batch", "async"] # TODO: Remove nightly after feature completed
 batch = ["heapless"]
+async =  ["display-interface/async", "display-interface/nightly"]

--- a/src/asynch/mod.rs
+++ b/src/asynch/mod.rs
@@ -1,0 +1,3 @@
+//! Module that gives async support for library
+
+pub mod models;

--- a/src/asynch/models.rs
+++ b/src/asynch/models.rs
@@ -1,0 +1,55 @@
+//! Async display model
+
+use display_interface::AsyncWriteOnlyDataCommand;
+use embedded_graphics_core::prelude::RgbColor;
+use embedded_hal::digital::OutputPin;
+use embedded_hal_async::delay::DelayUs;
+
+use crate::dcs::{Dcs, SetAddressMode};
+use crate::error::InitError;
+use crate::{Error, ModelOptions};
+
+/// Display model.
+pub trait Model {
+    /// The color format.
+    type ColorFormat: RgbColor;
+
+    /// Initializes the display for this model with MADCTL from [crate::Display]
+    /// and returns the value of MADCTL set by init
+    async fn init<RST, DELAY, DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+        rst: &mut Option<RST>,
+    ) -> Result<SetAddressMode, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs,
+        DI: AsyncWriteOnlyDataCommand;
+
+    /// Resets the display using a reset pin.
+    async fn hard_reset<RST, DELAY>(
+        &mut self,
+        rst: &mut RST,
+        delay: &mut DELAY,
+    ) -> Result<(), InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs,
+    {
+        rst.set_low().map_err(InitError::Pin)?;
+        delay.delay_us(10);
+        rst.set_high().map_err(InitError::Pin)?;
+
+        Ok(())
+    }
+
+    /// Writes pixels to the display IC via the given display interface.
+    ///
+    /// Any pixel color format conversion is done here.
+    async fn write_pixels<DI, I>(&mut self, di: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+    where
+        DI: AsyncWriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>;
+}

--- a/src/asynch/models.rs
+++ b/src/asynch/models.rs
@@ -7,10 +7,11 @@ use embedded_hal_async::delay::DelayUs;
 
 use crate::dcs::{Dcs, SetAddressMode};
 use crate::error::InitError;
+use crate::models::DefaultModel;
 use crate::{Error, ModelOptions};
 
 /// Display model.
-pub trait Model {
+pub trait Model: DefaultModel {
     /// The color format.
     type ColorFormat: RgbColor;
 

--- a/src/asynch/models.rs
+++ b/src/asynch/models.rs
@@ -40,7 +40,7 @@ pub trait Model: DefaultModel {
         DELAY: DelayUs,
     {
         rst.set_low().map_err(InitError::Pin)?;
-        delay.delay_us(10);
+        delay.delay_us(10).await;
         rst.set_high().map_err(InitError::Pin)?;
 
         Ok(())

--- a/src/asynch/models.rs
+++ b/src/asynch/models.rs
@@ -53,4 +53,15 @@ pub trait Model: DefaultModel {
     where
         DI: AsyncWriteOnlyDataCommand,
         I: IntoIterator<Item = Self::ColorFormat>;
+
+    /// Writes pixels to the display IC via the given display interface.
+    ///
+    /// Any pixel color format conversion is done here.
+    async fn write_pixels_raw<DI>(
+        &mut self,
+        di: &mut Dcs<DI>,
+        colors: &mut [u16],
+    ) -> Result<(), Error>
+    where
+        DI: AsyncWriteOnlyDataCommand;
 }

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -4,7 +4,7 @@
 use crate::{models::Model, Display, Error};
 use display_interface::WriteOnlyDataCommand;
 use embedded_graphics_core::prelude::*;
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::digital::OutputPin;
 
 pub trait DrawBatch<DI, M, I>
 where

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,7 @@
 //! [super::Display] builder module
 
 use display_interface::WriteOnlyDataCommand;
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::Dcs, error::InitError, models::Model, ColorInversion, ColorOrder, Display, ModelOptions,
@@ -114,7 +114,7 @@ where
     ///
     pub fn init<RST>(
         mut self,
-        delay_source: &mut impl DelayUs<u32>,
+        delay_source: &mut impl DelayUs,
         mut rst: Option<RST>,
     ) -> Result<Display<DI, MODEL, RST>, InitError<RST::Error>>
     where

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -124,7 +124,9 @@ where
         RST: OutputPin,
     {
         let mut dcs = Dcs::write_only(self.di);
-        let madctl = self.model.init(delay_source, &self.options, &mut rst)?;
+        let madctl = self
+            .model
+            .init(&mut dcs, delay_source, &self.options, &mut rst)?;
         let display = Display {
             dcs,
             model: self.model,
@@ -155,7 +157,7 @@ where
         let mut dcs = Dcs::write_only(self.di);
         let madctl = self
             .model
-            .init(delay_source, &self.options, &mut rst)
+            .init(&mut dcs, delay_source, &self.options, &mut rst)
             .await?;
         let display = Display {
             dcs,

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ use display_interface::DisplayError;
 pub enum InitError<PE> {
     /// Error caused by the display interface.
     DisplayError,
-    /// Error caused by the reset pin's [`OutputPin`](embedded_hal::digital::v2::OutputPin) implementation.
+    /// Error caused by the reset pin's [`OutputPin`](embedded_hal::digital::OutputPin) implementation.
     Pin(PE),
 }
 

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1,7 +1,7 @@
 use embedded_graphics_core::prelude::{DrawTarget, Point, RgbColor, Size};
 use embedded_graphics_core::primitives::Rectangle;
 use embedded_graphics_core::{prelude::OriginDimensions, Pixel};
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::digital::OutputPin;
 
 use crate::dcs::BitsPerPixel;
 use crate::models::Model;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ where
     ) -> Result<(), Error> {
         self.async_set_address_window(x, y, x, y).await?;
         self.model
-            .write_pixels_iter(&mut self.dcs, core::iter::once(color))
+            .write_pixels(&mut self.dcs, core::iter::once(color))
             .await?;
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,11 @@
 // associated re-typing not supported in rust yet
 #![allow(clippy::type_complexity)]
 #![warn(missing_docs)]
+#![cfg_attr(
+    all(feature = "async"),
+    allow(incomplete_features),
+    feature(async_fn_in_trait, impl_trait_projections)
+)]
 
 //! This crate provides a generic display driver to connect to TFT displays
 //! that implement the [MIPI Display Command Set](https://www.mipi.org/specifications/display-command-set).
@@ -50,6 +55,9 @@ pub mod dcs;
 
 pub mod models;
 use models::Model;
+
+#[cfg(feature = "async")]
+pub mod asynch;
 
 mod graphics;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,17 +201,17 @@ where
     }
 }
 
-#[cfg(feature = "nightly")]
+#[cfg(feature = "async")]
 impl<DI, M, RST> Display<DI, M, RST>
 where
-    DI: AsyncWriteOnlyDataCommand,
+    DI: display_interface::AsyncWriteOnlyDataCommand,
     M: crate::asynch::models::Model,
     RST: OutputPin,
 {
     ///  Async version of [Self::set_orientation]
     pub async fn async_set_orientation(&mut self, orientation: Orientation) -> Result<(), Error> {
         self.madctl = self.madctl.with_orientation(orientation); // set orientation
-        self.dcs.write_command(self.madctl).await?;
+        self.dcs.async_write_command(self.madctl).await?;
 
         Ok(())
     }
@@ -223,9 +223,9 @@ where
         y: u16,
         color: M::ColorFormat,
     ) -> Result<(), Error> {
-        self.asyn_set_address_window(x, y, x, y).await?;
+        self.async_set_address_window(x, y, x, y).await?;
         self.model
-            .write_pixels(&mut self.dcs, core::iter::once(color))
+            .write_pixels_iter(&mut self.dcs, core::iter::once(color))
             .await?;
 
         Ok(())
@@ -257,13 +257,13 @@ where
         bfa: u16,
     ) -> Result<(), Error> {
         let vscrdef = dcs::SetScrollArea::new(tfa, vsa, bfa);
-        self.dcs.write_command(vscrdef).await
+        self.dcs.async_write_command(vscrdef).await
     }
 
     ///  Async version of [Self::set_scroll_offset]
     pub async fn async_set_scroll_offset(&mut self, offset: u16) -> Result<(), Error> {
         let vscad = dcs::SetScrollStart::new(offset);
-        self.dcs.write_command(vscad).await
+        self.dcs.async_write_command(vscad).await
     }
 
     // Sets the address window for the display.
@@ -279,10 +279,10 @@ where
         let (sx, sy, ex, ey) = (sx + offset.0, sy + offset.1, ex + offset.0, ey + offset.1);
 
         self.dcs
-            .write_command(dcs::SetColumnAddress::new(sx, ex))
+            .async_write_command(dcs::SetColumnAddress::new(sx, ex))
             .await?;
         self.dcs
-            .write_command(dcs::SetPageAddress::new(sy, ey))
+            .async_write_command(dcs::SetPageAddress::new(sy, ey))
             .await
     }
 
@@ -292,6 +292,7 @@ where
         tearing_effect: TearingEffect,
     ) -> Result<(), Error> {
         self.dcs
-            .write_command(dcs::SetTearingEffect(tearing_effect))
+            .async_write_command(dcs::SetTearingEffect(tearing_effect))
+            .await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,31 @@ where
     }
 
     ///
+    /// Sets pixel colors in given rectangle bounds.
+    ///
+    /// # Arguments
+    ///
+    /// * `sx` - x coordinate start
+    /// * `sy` - y coordinate start
+    /// * `ex` - x coordinate end
+    /// * `ey` - y coordinate end
+    /// * `colors` - a buffer of u16
+    ///
+    pub fn set_pixels_raw(
+        &mut self,
+        sx: u16,
+        sy: u16,
+        ex: u16,
+        ey: u16,
+        colors: &mut [u16],
+    ) -> Result<(), Error> {
+        self.set_address_window(sx, sy, ex, ey)?;
+        self.model.write_pixels_raw(&mut self.dcs, colors)?;
+
+        Ok(())
+    }
+
+    ///
     /// Sets scroll region
     /// # Arguments
     ///
@@ -245,6 +270,31 @@ where
     {
         self.async_set_address_window(sx, sy, ex, ey).await?;
         self.model.write_pixels(&mut self.dcs, colors).await?;
+
+        Ok(())
+    }
+
+    ///
+    /// Sets pixel colors in given rectangle bounds.
+    ///
+    /// # Arguments
+    ///
+    /// * `sx` - x coordinate start
+    /// * `sy` - y coordinate start
+    /// * `ex` - x coordinate end
+    /// * `ey` - y coordinate end
+    /// * `colors` - a buffer of u16
+    ///
+    pub async fn async_set_pixels_raw(
+        &mut self,
+        sx: u16,
+        sy: u16,
+        ex: u16,
+        ey: u16,
+        colors: &mut [u16],
+    ) -> Result<(), Error> {
+        self.async_set_address_window(sx, sy, ex, ey).await?;
+        self.model.write_pixels_raw(&mut self.dcs, colors).await?;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ use dcs::Dcs;
 use display_interface::WriteOnlyDataCommand;
 
 pub mod error;
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::digital::OutputPin;
 pub use error::Error;
 
 pub mod options;

--- a/src/models.rs
+++ b/src/models.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use display_interface::WriteOnlyDataCommand;
 use embedded_graphics_core::prelude::RgbColor;
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 // existing model implementations
 mod gc9a01;
@@ -41,7 +41,7 @@ pub trait Model {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand;
 
     /// Resets the display using a reset pin.
@@ -52,7 +52,7 @@ pub trait Model {
     ) -> Result<(), InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
     {
         rst.set_low().map_err(InitError::Pin)?;
         delay.delay_us(10);

--- a/src/models.rs
+++ b/src/models.rs
@@ -25,6 +25,7 @@ pub use ili9486::*;
 pub use st7735s::*;
 pub use st7789::*;
 
+/// Trait that allows the creations of default options for a [Model]
 pub trait DefaultModel {
     /// Creates default [ModelOptions] for this particular [Model].
     ///

--- a/src/models.rs
+++ b/src/models.rs
@@ -25,8 +25,16 @@ pub use ili9486::*;
 pub use st7735s::*;
 pub use st7789::*;
 
+pub trait DefaultModel {
+    /// Creates default [ModelOptions] for this particular [Model].
+    ///
+    /// This serves as a "sane default". There can be additional variants which will be provided via
+    /// helper constructors.
+    fn default_options() -> ModelOptions;
+}
+
 /// Display model.
-pub trait Model {
+pub trait Model: DefaultModel {
     /// The color format.
     type ColorFormat: RgbColor;
 
@@ -68,10 +76,4 @@ pub trait Model {
     where
         DI: WriteOnlyDataCommand,
         I: IntoIterator<Item = Self::ColorFormat>;
-
-    /// Creates default [ModelOptions] for this particular [Model].
-    ///
-    /// This serves as a "sane default". There can be additional variants which will be provided via
-    /// helper constructors.
-    fn default_options() -> ModelOptions;
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -81,11 +81,7 @@ pub trait Model: DefaultModel {
     /// Writes pixels to the display IC via the given display interface.
     ///
     /// Any pixel color format conversion is done before.
-    async fn write_pixels_raw<DI>(
-        &mut self,
-        dcs: &mut Dcs<DI>,
-        colors: &mut [u16],
-    ) -> Result<(), Error>
+    fn write_pixels_raw<DI>(&mut self, dcs: &mut Dcs<DI>, colors: &mut [u16]) -> Result<(), Error>
     where
         DI: WriteOnlyDataCommand;
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -10,19 +10,19 @@ use embedded_graphics_core::prelude::RgbColor;
 use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 // existing model implementations
-mod gc9a01;
-mod ili9341;
-mod ili9342c;
-mod ili934x;
-mod ili9486;
-mod st7735s;
+// mod gc9a01;
+// mod ili9341;
+// mod ili9342c;
+// mod ili934x;
+// mod ili9486;
+// mod st7735s;
 mod st7789;
 
-pub use gc9a01::*;
-pub use ili9341::*;
-pub use ili9342c::*;
-pub use ili9486::*;
-pub use st7735s::*;
+// pub use gc9a01::*;
+// pub use ili9341::*;
+// pub use ili9342c::*;
+// pub use ili9486::*;
+// pub use st7735s::*;
 pub use st7789::*;
 
 /// Trait that allows the creations of default options for a [Model]
@@ -77,4 +77,15 @@ pub trait Model: DefaultModel {
     where
         DI: WriteOnlyDataCommand,
         I: IntoIterator<Item = Self::ColorFormat>;
+
+    /// Writes pixels to the display IC via the given display interface.
+    ///
+    /// Any pixel color format conversion is done before.
+    async fn write_pixels_raw<DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        colors: &mut [u16],
+    ) -> Result<(), Error>
+    where
+        DI: WriteOnlyDataCommand;
 }

--- a/src/models/gc9a01.rs
+++ b/src/models/gc9a01.rs
@@ -11,10 +11,16 @@ use crate::{
     Builder, Error, ModelOptions,
 };
 
-use super::{Dcs, Model};
+use super::{Dcs, DefaultModel, Model};
 
 /// GC9A01 display in Rgb565 color mode.
 pub struct GC9A01;
+
+impl DefaultModel for GC9A01 {
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((240, 240), (240, 240))
+    }
+}
 
 impl Model for GC9A01 {
     type ColorFormat = Rgb565;
@@ -140,10 +146,6 @@ impl Model for GC9A01 {
         let buf = DataFormat::U16BEIter(&mut iter);
         dcs.di.send_data(buf)?;
         Ok(())
-    }
-
-    fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((240, 240), (240, 240))
     }
 }
 

--- a/src/models/gc9a01.rs
+++ b/src/models/gc9a01.rs
@@ -1,6 +1,6 @@
 use display_interface::{DataFormat, WriteOnlyDataCommand};
 use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{
@@ -8,7 +8,7 @@ use crate::{
         SetPixelFormat, SoftReset, WriteMemoryStart,
     },
     error::InitError,
-    Builder, ColorInversion, Error, ModelOptions,
+    Builder, Error, ModelOptions,
 };
 
 use super::{Dcs, Model};
@@ -28,7 +28,7 @@ impl Model for GC9A01 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         let madctl = SetAddressMode::from(options);

--- a/src/models/ili9341.rs
+++ b/src/models/ili9341.rs
@@ -1,6 +1,6 @@
 use display_interface::WriteOnlyDataCommand;
 use embedded_graphics_core::pixelcolor::{Rgb565, Rgb666};
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{BitsPerPixel, Dcs, PixelFormat, SetAddressMode, SoftReset},
@@ -27,7 +27,7 @@ impl Model for ILI9341Rgb565 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {
@@ -64,7 +64,7 @@ impl Model for ILI9341Rgb666 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {

--- a/src/models/ili9341.rs
+++ b/src/models/ili9341.rs
@@ -9,11 +9,25 @@ use crate::{
     Builder, Error, ModelOptions,
 };
 
+use super::DefaultModel;
+
 /// ILI9341 display in Rgb565 color mode.
 pub struct ILI9341Rgb565;
 
 /// ILI9341 display in Rgb666 color mode.
 pub struct ILI9341Rgb666;
+
+impl DefaultModel for ILI9341Rgb565 {
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((240, 320), (240, 320))
+    }
+}
+
+impl DefaultModel for ILI9341Rgb666 {
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((240, 320), (240, 320))
+    }
+}
 
 impl Model for ILI9341Rgb565 {
     type ColorFormat = Rgb565;
@@ -45,10 +59,6 @@ impl Model for ILI9341Rgb565 {
         I: IntoIterator<Item = Self::ColorFormat>,
     {
         ili934x::write_pixels_rgb565(dcs, colors)
-    }
-
-    fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((240, 320), (240, 320))
     }
 }
 
@@ -82,10 +92,6 @@ impl Model for ILI9341Rgb666 {
         I: IntoIterator<Item = Self::ColorFormat>,
     {
         ili934x::write_pixels_rgb666(dcs, colors)
-    }
-
-    fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((240, 320), (240, 320))
     }
 }
 

--- a/src/models/ili9342c.rs
+++ b/src/models/ili9342c.rs
@@ -1,6 +1,6 @@
 use display_interface::WriteOnlyDataCommand;
 use embedded_graphics_core::pixelcolor::{Rgb565, Rgb666};
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{BitsPerPixel, Dcs, PixelFormat, SetAddressMode, SoftReset},
@@ -27,7 +27,7 @@ impl Model for ILI9342CRgb565 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {
@@ -64,7 +64,7 @@ impl Model for ILI9342CRgb666 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {

--- a/src/models/ili9342c.rs
+++ b/src/models/ili9342c.rs
@@ -9,11 +9,25 @@ use crate::{
     Builder, Error, ModelOptions,
 };
 
+use super::DefaultModel;
+
 /// ILI9342C display in Rgb565 color mode.
 pub struct ILI9342CRgb565;
 
 /// ILI9342C display in Rgb666 color mode.
 pub struct ILI9342CRgb666;
+
+impl DefaultModel for ILI9342CRgb565 {
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((320, 240), (320, 240))
+    }
+}
+
+impl DefaultModel for ILI9342CRgb666 {
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((320, 240), (320, 240))
+    }
+}
 
 impl Model for ILI9342CRgb565 {
     type ColorFormat = Rgb565;
@@ -45,10 +59,6 @@ impl Model for ILI9342CRgb565 {
         I: IntoIterator<Item = Self::ColorFormat>,
     {
         ili934x::write_pixels_rgb565(dcs, colors)
-    }
-
-    fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((320, 240), (320, 240))
     }
 }
 
@@ -82,10 +92,6 @@ impl Model for ILI9342CRgb666 {
         I: IntoIterator<Item = Self::ColorFormat>,
     {
         ili934x::write_pixels_rgb666(dcs, colors)
-    }
-
-    fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((320, 240), (320, 240))
     }
 }
 

--- a/src/models/ili934x.rs
+++ b/src/models/ili934x.rs
@@ -1,6 +1,6 @@
 use display_interface::{DataFormat, WriteOnlyDataCommand};
 use embedded_graphics_core::pixelcolor::{IntoStorage, Rgb565, Rgb666, RgbColor};
-use embedded_hal::blocking::delay::DelayUs;
+use embedded_hal::delay::DelayUs;
 
 use crate::{
     dcs::{
@@ -18,7 +18,7 @@ pub fn init_common<DELAY, DI>(
     pixel_format: PixelFormat,
 ) -> Result<SetAddressMode, Error>
 where
-    DELAY: DelayUs<u32>,
+    DELAY: DelayUs,
     DI: WriteOnlyDataCommand,
 {
     let madctl = SetAddressMode::from(options);

--- a/src/models/ili9486.rs
+++ b/src/models/ili9486.rs
@@ -3,7 +3,7 @@ use embedded_graphics_core::{
     pixelcolor::{Rgb565, Rgb666},
     prelude::{IntoStorage, RgbColor},
 };
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{
@@ -34,7 +34,7 @@ impl Model for ILI9486Rgb565 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {
@@ -76,7 +76,7 @@ impl Model for ILI9486Rgb666 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {
@@ -160,7 +160,7 @@ fn init_common<DELAY, DI>(
     pixel_format: PixelFormat,
 ) -> Result<SetAddressMode, Error>
 where
-    DELAY: DelayUs<u32>,
+    DELAY: DelayUs,
     DI: WriteOnlyDataCommand,
 {
     let madctl = SetAddressMode::from(options);

--- a/src/models/ili9486.rs
+++ b/src/models/ili9486.rs
@@ -14,13 +14,25 @@ use crate::{
     Builder, Error, ModelOptions,
 };
 
-use super::Model;
+use super::{DefaultModel, Model};
 
 /// ILI9486 display in Rgb565 color mode.
 pub struct ILI9486Rgb565;
 
 /// ILI9486 display in Rgb666 color mode.
 pub struct ILI9486Rgb666;
+
+impl DefaultModel for ILI9486Rgb565 {
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((320, 480), (320, 480))
+    }
+}
+
+impl DefaultModel for ILI9486Rgb666 {
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((320, 480), (320, 480))
+    }
+}
 
 impl Model for ILI9486Rgb565 {
     type ColorFormat = Rgb565;
@@ -57,10 +69,6 @@ impl Model for ILI9486Rgb565 {
 
         let buf = DataFormat::U16BEIter(&mut iter);
         dcs.di.send_data(buf)
-    }
-
-    fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((320, 480), (320, 480))
     }
 }
 
@@ -105,10 +113,6 @@ impl Model for ILI9486Rgb666 {
 
         let buf = DataFormat::U8Iter(&mut iter);
         dcs.di.send_data(buf)
-    }
-
-    fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((320, 480), (320, 480))
     }
 }
 

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -1,6 +1,6 @@
 use display_interface::{DataFormat, WriteOnlyDataCommand};
 use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{
@@ -28,7 +28,7 @@ impl Model for ST7735s {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         let madctl = SetAddressMode::from(options);

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -11,10 +11,19 @@ use crate::{
     Builder, ColorInversion, Error, ModelOptions,
 };
 
-use super::{Dcs, Model};
+use super::{Dcs, DefaultModel, Model};
 
 /// ST7735s display in Rgb565 color mode.
 pub struct ST7735s;
+
+impl DefaultModel for ST7735s {
+    fn default_options() -> ModelOptions {
+        let mut options = ModelOptions::with_sizes((80, 160), (132, 162));
+        options.set_invert_colors(ColorInversion::Inverted);
+
+        options
+    }
+}
 
 impl Model for ST7735s {
     type ColorFormat = Rgb565;
@@ -89,21 +98,11 @@ impl Model for ST7735s {
         dcs.di.send_data(buf)?;
         Ok(())
     }
-
-    fn default_options() -> ModelOptions {
-        let mut options = ModelOptions::with_sizes((80, 160), (132, 162));
-        options.set_invert_colors(ColorInversion::Inverted);
-
-        options
-    }
 }
 
 // simplified constructor on Display
 
-impl<DI> Builder<DI, ST7735s>
-where
-    DI: WriteOnlyDataCommand,
-{
+impl<DI> Builder<DI, ST7735s> {
     /// Creates a new display builder for ST7735s displays in Rgb565 color mode.
     ///
     /// The default framebuffer size is 132x162 pixels and display size is 80x160 pixels.

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -1,6 +1,6 @@
 use display_interface::{DataFormat, WriteOnlyDataCommand};
 use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{
@@ -33,7 +33,7 @@ impl Model for ST7789 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         let madctl = SetAddressMode::from(options);

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -89,11 +89,7 @@ impl Model for ST7789 {
         Ok(())
     }
 
-    async fn write_pixels_raw<DI>(
-        &mut self,
-        dcs: &mut Dcs<DI>,
-        colors: &mut [u16],
-    ) -> Result<(), Error>
+    fn write_pixels_raw<DI>(&mut self, dcs: &mut Dcs<DI>, colors: &mut [u16]) -> Result<(), Error>
     where
         DI: WriteOnlyDataCommand,
     {

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -88,6 +88,20 @@ impl Model for ST7789 {
         dcs.di.send_data(buf)?;
         Ok(())
     }
+
+    async fn write_pixels_raw<DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        colors: &mut [u16],
+    ) -> Result<(), Error>
+    where
+        DI: WriteOnlyDataCommand,
+    {
+        dcs.write_command(WriteMemoryStart)?;
+        let buf = DataFormat::U16BE(colors);
+        dcs.di.send_data(buf)?;
+        Ok(())
+    }
 }
 
 #[cfg(feature = "async")]
@@ -168,6 +182,20 @@ mod asynch {
             let mut iter = colors.into_iter().map(Rgb565::into_storage);
 
             let buf = DataFormat::U16BEIter(&mut iter);
+            dcs.di.send_data(buf).await?;
+            Ok(())
+        }
+
+        async fn write_pixels_raw<DI>(
+            &mut self,
+            dcs: &mut Dcs<DI>,
+            colors: &mut [u16],
+        ) -> Result<(), Error>
+        where
+            DI: AsyncWriteOnlyDataCommand,
+        {
+            dcs.async_write_command(WriteMemoryStart).await?;
+            let buf = DataFormat::U16BE(colors);
             dcs.di.send_data(buf).await?;
             Ok(())
         }

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -87,3 +87,87 @@ impl Model for ST7789 {
         options
     }
 }
+
+#[cfg(feature = "async")]
+mod asynch {
+    use display_interface::{AsyncWriteOnlyDataCommand, DataFormat};
+    use embedded_graphics_core::pixelcolor::IntoStorage;
+    use embedded_graphics_core::pixelcolor::Rgb565;
+    use embedded_hal::digital::OutputPin;
+    use embedded_hal_async::delay::DelayUs;
+
+    use crate::{
+        asynch::models::Model,
+        dcs::{
+            BitsPerPixel, Dcs, EnterNormalMode, ExitSleepMode, PixelFormat, SetAddressMode,
+            SetDisplayOn, SetInvertMode, SetPixelFormat, SetScrollArea, SoftReset,
+            WriteMemoryStart,
+        },
+        error::InitError,
+        Error, ModelOptions,
+    };
+
+    use super::ST7789;
+
+    impl Model for ST7789 {
+        type ColorFormat = Rgb565;
+
+        async fn init<RST, DELAY, DI>(
+            &mut self,
+            dcs: &mut Dcs<DI>,
+            delay: &mut DELAY,
+            options: &ModelOptions,
+            rst: &mut Option<RST>,
+        ) -> Result<SetAddressMode, InitError<RST::Error>>
+        where
+            RST: OutputPin,
+            DELAY: DelayUs,
+            DI: AsyncWriteOnlyDataCommand,
+        {
+            let madctl = SetAddressMode::from(options);
+
+            match rst {
+                Some(ref mut rst) => self.hard_reset(rst, delay).await?,
+                None => dcs.async_write_command(SoftReset).await?,
+            }
+            delay.delay_us(150_000).await;
+
+            dcs.async_write_command(ExitSleepMode).await?;
+            delay.delay_us(10_000).await;
+
+            // set hw scroll area based on framebuffer size
+            dcs.async_write_command(SetScrollArea::from(options))
+                .await?;
+            dcs.async_write_command(madctl).await?;
+
+            dcs.async_write_command(SetInvertMode(options.invert_colors))
+                .await?;
+
+            let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+            dcs.async_write_command(SetPixelFormat::new(pf)).await?;
+            delay.delay_us(10_000).await;
+            dcs.async_write_command(EnterNormalMode).await?;
+            delay.delay_us(10_000).await;
+            dcs.async_write_command(SetDisplayOn).await?;
+
+            // DISPON requires some time otherwise we risk SPI data issues
+            delay.delay_us(120_000).await;
+
+            Ok(madctl)
+        }
+
+        async fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+        where
+            DI: AsyncWriteOnlyDataCommand,
+            I: IntoIterator<Item = Self::ColorFormat>,
+        {
+            dcs.async_write_command(WriteMemoryStart).await?;
+
+            let mut iter = colors.into_iter().map(Rgb565::into_storage);
+
+            let buf = DataFormat::U16BEIter(&mut iter);
+            dcs.di.send_data(buf).await?;
+            Ok(())
+        }
+    }
+}

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -11,7 +11,7 @@ use crate::{
     ColorInversion, Error, ModelOptions,
 };
 
-use super::Model;
+use super::{DefaultModel, Model};
 
 /// Module containing all ST7789 variants.
 mod variants;
@@ -20,6 +20,15 @@ mod variants;
 ///
 /// Interfaces implemented by the [display-interface](https://crates.io/crates/display-interface) are supported.
 pub struct ST7789;
+
+impl DefaultModel for ST7789 {
+    fn default_options() -> crate::ModelOptions {
+        let mut options = ModelOptions::with_sizes((240, 320), (240, 320));
+        options.set_invert_colors(ColorInversion::Normal);
+
+        options
+    }
+}
 
 impl Model for ST7789 {
     type ColorFormat = Rgb565;
@@ -78,13 +87,6 @@ impl Model for ST7789 {
         let buf = DataFormat::U16BEIter(&mut iter);
         dcs.di.send_data(buf)?;
         Ok(())
-    }
-
-    fn default_options() -> crate::ModelOptions {
-        let mut options = ModelOptions::with_sizes((240, 320), (240, 320));
-        options.set_invert_colors(ColorInversion::Normal);
-
-        options
     }
 }
 

--- a/src/models/st7789/variants.rs
+++ b/src/models/st7789/variants.rs
@@ -1,13 +1,8 @@
-use display_interface::WriteOnlyDataCommand;
-
 use crate::{Builder, ColorInversion, ModelOptions, Orientation};
 
 use super::ST7789;
 
-impl<DI> Builder<DI, ST7789>
-where
-    DI: WriteOnlyDataCommand,
-{
+impl<DI> Builder<DI, ST7789> {
     /// Creates a new display builder for a ST7789 display in Rgb565 color mode.
     ///
     /// The default framebuffer size and display size is 240x320 pixels.


### PR DESCRIPTION
Exploratory work for async support. Based on the async draft done [here](https://github.com/therealprof/display-interface/pull/36). The goal of the PR is not to merge the changes, but more to discuss an async api and discuss the possible shortcomings.

I've tested and benchmarked a bit using the st7789v2 on an nrf52840 using embassy.

From my tests,  mipidsi  use of an iterator of color is quite limiting (even for sync), using a raw slice of u16 improved the rendering speed quite a lot. The iterator api should probably be avoided for async for big writes since it would wake the task quite a lot. It will give significantly worse performance than the sync api since all the wakes are probably not negligible due to the quantity of it.  

For the sync api, I tested using a slice instead of an iterator and drawing speed increased by about 1.25 to 1.5 times.

The iterator api allows a lot of flexibility and is nice to work with, but leaves a lot of performance on the table.

Providing a "raw" api would probably be interesting. For example if I had enough memory and send the full display to be redrawn, using the current async api from the PR with iterators, it would cause 900 wakes (display-interface-spi splits in packets 64 for `U16BEIter` and the st7789v2 has `240*240`).

I'm not sure if you were interested in an async api at all, but just wanted to share the information I've collected.

Also note that in the PR, only the changes for st7789 were done, but it would be pretty similar for the rest of the models.

@almindor let me know what you think!