### PR TITLE
Amplify documentation and add example

### DIFF
--- a/examples/parallel_ili9341_rp_pico/.cargo/config.toml
+++ b/examples/parallel_ili9341_rp_pico/.cargo/config.toml
@@ -1,0 +1,32 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+# Choose a default "cargo run" tool:
+# - probe-run provides flashing and defmt via a hardware debugger
+# - cargo embed offers flashing, rtt, defmt and a gdb server via a hardware debugger
+#     it is configured via the Embed.toml in the root of this project
+# - elf2uf2-rs loads firmware over USB when the rp2040 is in boot mode
+# runner = "probe-run --chip RP2040"
+# runner = "cargo embed"
+runner = "elf2uf2-rs -d"
+
+rustflags = [
+  "-C", "linker=flip-link",
+  "-C", "link-arg=--nmagic",
+  "-C", "link-arg=-Tlink.x",
+  "-C", "link-arg=-Tdefmt.x",
+
+  # Code-size optimizations.
+  #   trap unreachable can save a lot of space, but requires nightly compiler.
+  #   uncomment the next line if you wish to enable it
+  # "-Z", "trap-unreachable=no",
+  "-C", "inline-threshold=5",
+  "-C", "no-vectorize-loops",
+]
+
+[build]
+target = "thumbv6m-none-eabi"
+
+[env]
+DEFMT_LOG = "debug"
+
+[target.thumbv6m-none-eabi]
+runner = "elf2uf2-rs -d"

--- a/examples/parallel_ili9341_rp_pico/Cargo.toml
+++ b/examples/parallel_ili9341_rp_pico/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+edition = "2021"
+name = "parallel_ili9341_rp_pico"
+version = "0.1.0"
+
+[dependencies]
+cortex-m = "0.7"
+cortex-m-rt = "0.7"
+embedded-hal = { version = "0.2.5", features = ["unproven"] }
+
+defmt = "0.3"
+defmt-rtt = "0.4"
+panic-probe = { version = "0.3", features = ["print-defmt"] }
+
+rp-pico = "0.7"
+
+embedded-graphics = "0.8.0"
+embedded-graphics-core = "0.4.0"
+display-interface-parallel-gpio = "0.6.0"
+mipidsi = "0.7.1"

--- a/examples/parallel_ili9341_rp_pico/build.rs
+++ b/examples/parallel_ili9341_rp_pico/build.rs
@@ -1,0 +1,31 @@
+//! This build script copies the `memory.x` file from the crate root into
+//! a directory where the linker can always find it at build time.
+//! For many projects this is optional, as the linker always searches the
+//! project root directory -- wherever `Cargo.toml` is. However, if you
+//! are using a workspace or have a more complicated build setup, this
+//! build script becomes required. Additionally, by requesting that
+//! Cargo re-run the build script whenever `memory.x` is changed,
+//! updating `memory.x` ensures a rebuild of the application with the
+//! new memory settings.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Put `memory.x` in our output directory and ensure it's
+    // on the linker search path.
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    // By default, Cargo will re-run a build script whenever
+    // any file in the project changes. By specifying `memory.x`
+    // here, we ensure the build script is only re-run when
+    // `memory.x` is changed.
+    println!("cargo:rerun-if-changed=memory.x");
+}

--- a/examples/parallel_ili9341_rp_pico/memory.x
+++ b/examples/parallel_ili9341_rp_pico/memory.x
@@ -1,0 +1,15 @@
+MEMORY {
+    BOOT2 : ORIGIN = 0x10000000, LENGTH = 0x100
+    FLASH : ORIGIN = 0x10000100, LENGTH = 2048K - 0x100
+    RAM   : ORIGIN = 0x20000000, LENGTH = 256K
+}
+
+EXTERN(BOOT2_FIRMWARE)
+
+SECTIONS {
+    /* ### Boot loader */
+    .boot2 ORIGIN(BOOT2) :
+    {
+        KEEP(*(.boot2));
+    } > BOOT2
+} INSERT BEFORE .text;

--- a/examples/parallel_ili9341_rp_pico/src/main.rs
+++ b/examples/parallel_ili9341_rp_pico/src/main.rs
@@ -1,0 +1,110 @@
+// This example is made for the Raspberry Pi Pico, using the `rp-hal`
+// It demonstrates how to set up an ili9341 display with the Rgb666 color space
+// using a parallel port
+
+/* --- Needed by RPI Pico --- */
+#![no_std]
+#![no_main]
+use bsp::entry;
+use bsp::hal::{
+    clocks::{init_clocks_and_plls, Clock},
+    gpio, pac,
+    sio::Sio,
+    watchdog::Watchdog,
+};
+use defmt_rtt as _;
+use panic_probe as _;
+use rp_pico as bsp;
+/* -------------------------- */
+
+use embedded_graphics::{
+    // Provides the necessary functions to draw on the display
+    draw_target::DrawTarget,
+    // Provides colors from the Rgb666 color space
+    pixelcolor::Rgb666,
+    prelude::RgbColor,
+};
+
+// Provides the parallel port and display interface builders
+use display_interface_parallel_gpio::{Generic8BitBus, PGPIO8BitInterface};
+
+// Provides the Display builder
+use mipidsi::Builder;
+
+#[entry]
+fn main() -> ! {
+    // Define the pico's singleton objects
+    let mut pac = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+    let sio = Sio::new(pac.SIO);
+
+    // Define the pico's clocks, needed for the delay
+    let external_xtal_freq_hz = 12_000_000u32;
+    let clocks = init_clocks_and_plls(
+        external_xtal_freq_hz,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    // Define the delay struct, needed for the display driver
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().to_Hz());
+
+    // Define the pins, needed to define the display interface
+    let pins = bsp::Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    // Define the reset and write enable pins as digital outputs and make them high
+    let rst = pins
+        .gpio7
+        .into_push_pull_output_in_state(gpio::PinState::High);
+    let wr = pins
+        .gpio5
+        .into_push_pull_output_in_state(gpio::PinState::High);
+
+    // Define the Data/Command select pin as a digital output
+    let dc = pins.gpio6.into_push_pull_output();
+
+    // Define the pins used for the parallel interface as digital outputs
+    let lcd_d0 = pins.gpio15.into_push_pull_output();
+    let lcd_d1 = pins.gpio14.into_push_pull_output();
+    let lcd_d2 = pins.gpio13.into_push_pull_output();
+    let lcd_d3 = pins.gpio12.into_push_pull_output();
+    let lcd_d4 = pins.gpio11.into_push_pull_output();
+    let lcd_d5 = pins.gpio10.into_push_pull_output();
+    let lcd_d6 = pins.gpio9.into_push_pull_output();
+    let lcd_d7 = pins.gpio8.into_push_pull_output();
+
+    // Define the parallel bus with the previously defined parallel port pins
+    let bus = Generic8BitBus::new((
+        lcd_d0, lcd_d1, lcd_d2, lcd_d3, lcd_d4, lcd_d5, lcd_d6, lcd_d7,
+    ))
+    .unwrap();
+
+    // Define the display interface from a generic 8 bit bus, a Data/Command select pin and a write enable pin
+    let di = PGPIO8BitInterface::new(bus, dc, wr);
+
+    // Define the display from the display bus, set the color order as Bgr and initialize it with
+    // the delay struct and the reset pin
+    let mut display = Builder::ili9341_rgb666(di)
+        .with_color_order(mipidsi::ColorOrder::Bgr)
+        .init(&mut delay, Some(rst))
+        .unwrap();
+
+    // Set the display all red
+    display.clear(Rgb666::RED).unwrap();
+
+    loop {
+        // Do nothing
+    }
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -11,6 +11,15 @@ use crate::{
 /// Builder for [Display] instances.
 ///
 /// Exposes all possible display options.
+///
+///
+/// ## Example
+/// ```
+/// let mut display = Builder::ili9342c_rgb565(di)
+///     .with_color_order(ColorOrder::Bgr);
+///     .with_display_size(320, 240);
+///     .init(&mut delay, Some(rst)).unwrap();
+/// ```
 pub struct Builder<DI, MODEL>
 where
     DI: WriteOnlyDataCommand,
@@ -108,10 +117,10 @@ where
     ///
     /// Consumes the builder to create a new [Display] with an optional reset [OutputPin].
     /// Blocks using the provided [DelayUs] `delay_source` to perform the display initialization.
+    ///
     /// ### WARNING
     /// The reset pin needs to be in *high* state in order for the display to operate.
     /// If it wasn't provided the user needs to ensure this is the case.
-    ///
     pub fn init<RST>(
         mut self,
         delay_source: &mut impl DelayUs<u32>,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -14,7 +14,7 @@ use crate::{
 ///
 ///
 /// ## Example
-/// ```
+/// ```rust ignore
 /// let mut display = Builder::ili9342c_rgb565(di)
 ///     .with_color_order(ColorOrder::Bgr);
 ///     .with_display_size(320, 240);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //! display.clear(Rgb666::BLACK).unwrap();
 //! ```
 //!
-//! **For the ili9341 display, using the Parallel port, with the RGB666 color space and the Bgr 
+//! **For the ili9341 display, using the Parallel port, with the RGB666 color space and the Bgr
 //! color order:**
 //! ```rust ignore
 //! // Provides the builder for DisplayInterface
@@ -52,11 +52,11 @@
 //!
 //! /* Define digital output pins d0 - d7 for the parallel port as `lcd_dX` */
 //! /* Define the D/C digital output pin as `dc` */
-//! /* Define the WR and Reset digital output pins with the initial state set as High as `wr` and 
+//! /* Define the WR and Reset digital output pins with the initial state set as High as `wr` and
 //! `rst` */
 //!
 //! // Create the DisplayInterface from a Generic8BitBus, which is made from the parallel pins
-//! let bus = Generic8BitBus::new((lcd_d0, lcd_d1, lcd_d2, 
+//! let bus = Generic8BitBus::new((lcd_d0, lcd_d1, lcd_d2,
 //!     lcd_d3, lcd_d4, lcd_d5, lcd_d6, lcd_d7)).unwrap();
 //! let di = PGPIO8BitInterface::new(bus, dc, wr);
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,20 +18,57 @@
 //! * ILI9341
 //! * ILI9342C
 //!
-//! ## Example
+//! ## Examples
+//! **For the ili9486 display, using the SPI interface with no chip select:** 
 //! ```rust ignore
-//! // create a DisplayInterface from SPI and DC pin, with no manual CS control
+//! use display_interface_spi::SPIInterfaceNoCS;    // Provides the builder for DisplayInterface
+//! use mipidsi::Builder;                           // Provides the builder for Display
+//! use embedded_graphics::pixelcolor::Rgb666;      // Provides the required color type
+//! 
+//! /* Define the SPI interface as the variable `spi` */
+//! /* Define the DC digital output pin as the variable `dc` */
+//! /* Define the Reset digital output pin as the variable `rst` */
+//! 
+//! // Create a DisplayInterface from SPI and DC pin, with no manual CS control
 //! let di = SPIInterfaceNoCS::new(spi, dc);
-//! // create the ILI9486 display driver from the display interface and optional RST pin
+//!
+//! // Create the ILI9486 display driver from the display interface and optional RST pin
 //! let mut display = Builder::ili9486(di)
-//!     .init(&mut delay, Some(rst));
-//! // clear the display to black
+//!     .init(&mut delay, Some(rst)).unwrap();
+//!
+//! // Clear the display to black
 //! display.clear(Rgb666::BLACK).unwrap();
 //! ```
 //!
+//! **For the ili9341 display, using the Parallel port, with the RGB666 color space and the Bgr color order:**
+//! ```rust ignore
+//! use display_interface_parallel_gpio::{Generic8BitBus, PGPIO8BitInterface};  // Provides the builder for DisplayInterface
+//! use mipidsi::Builder;                                                       // Provides the builder for Display
+//! use embedded_graphics::pixelcolor::Rgb666;                                  // Provides the required color type
+//!
+//! /* Define digital output pins d0 - d7 for the parallel port as `lcd_dX` */
+//! /* Define the D/C digital output pin as `dc` */
+//! /* Define the WR and Reset digital output pins with the initial state set as High as `wr` and `rst` */
+//! 
+//! // Create the DisplayInterface from a Generic8BitBus, which is provided all the parallel port pins
+//! let bus = Generic8BitBus::new((lcd_d0, lcd_d1, lcd_d2, lcd_d3, lcd_d4, lcd_d5, lcd_d6, lcd_d7)).unwrap();
+//! let di = PGPIO8BitInterface::new(bus, dc, wr);
+//!
+//! // Create the ILI9341 display driver from the display interface with the RGB666 color space
+//! let mut display = Builder::ili9341_rgb666(di)
+//!      .with_color_order(mipidsi::ColorOrder::Bgr)
+//!      .init(&mut delay, Some(rst)).unwrap();
+//! 
+//! // Clear the display to black
+//! display.clear(Rgb666::RED).unwrap();
+//! ```
+//! Use the appropiate display interface crate for your needs:
+//! - [`display-interface-spi`](https://docs.rs/display-interface-spi/)
+//! - [`display-interface-parallel-gpio`](https://docs.rs/display-interface-parallel-gpio)
+//! - [`display-interface-i2c`](https://docs.rs/display-interface-i2c/)
+//! 
 //! ## Troubleshooting
 //! See [document](https://github.com/almindor/mipidsi/blob/master/docs/TROUBLESHOOTING.md)
-//!
 
 use dcs::Dcs;
 use display_interface::WriteOnlyDataCommand;
@@ -91,8 +128,12 @@ where
     }
 
     ///
-    /// Sets display [Orientation]
+    /// Sets display [Orientation] with mirror image parameter
     ///
+    /// # Example
+    /// ```
+    /// display.orientation(Orientation::Portrait(false)).unwrap();
+    /// ```
     pub fn set_orientation(&mut self, orientation: Orientation) -> Result<(), Error> {
         self.madctl = self.madctl.with_orientation(orientation); // set orientation
         self.dcs.write_command(self.madctl)?;
@@ -109,6 +150,10 @@ where
     /// * `y` - y coordinate
     /// * `color` - the color value in pixel format of the display [Model]
     ///
+    /// # Example
+    /// ```
+    /// display.set_pixel(100, 200, Rgb666::new(251, 188, 20)).unwrap();
+    /// ```
     pub fn set_pixel(&mut self, x: u16, y: u16, color: M::ColorFormat) -> Result<(), Error> {
         self.set_address_window(x, y, x, y)?;
         self.model
@@ -127,7 +172,7 @@ where
     /// * `ex` - x coordinate end
     /// * `ey` - y coordinate end
     /// * `colors` - anything that can provide `IntoIterator<Item = u16>` to iterate over pixel data
-    ///
+    /// 
     pub fn set_pixels<T>(
         &mut self,
         sx: u16,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,16 +19,16 @@
 //! * ILI9342C
 //!
 //! ## Examples
-//! **For the ili9486 display, using the SPI interface with no chip select:** 
+//! **For the ili9486 display, using the SPI interface with no chip select:**
 //! ```rust ignore
 //! use display_interface_spi::SPIInterfaceNoCS;    // Provides the builder for DisplayInterface
 //! use mipidsi::Builder;                           // Provides the builder for Display
 //! use embedded_graphics::pixelcolor::Rgb666;      // Provides the required color type
-//! 
+//!
 //! /* Define the SPI interface as the variable `spi` */
 //! /* Define the DC digital output pin as the variable `dc` */
 //! /* Define the Reset digital output pin as the variable `rst` */
-//! 
+//!
 //! // Create a DisplayInterface from SPI and DC pin, with no manual CS control
 //! let di = SPIInterfaceNoCS::new(spi, dc);
 //!
@@ -40,25 +40,31 @@
 //! display.clear(Rgb666::BLACK).unwrap();
 //! ```
 //!
-//! **For the ili9341 display, using the Parallel port, with the RGB666 color space and the Bgr color order:**
+//! **For the ili9341 display, using the Parallel port, with the RGB666 color space and the Bgr 
+//! color order:**
 //! ```rust ignore
-//! use display_interface_parallel_gpio::{Generic8BitBus, PGPIO8BitInterface};  // Provides the builder for DisplayInterface
-//! use mipidsi::Builder;                                                       // Provides the builder for Display
-//! use embedded_graphics::pixelcolor::Rgb666;                                  // Provides the required color type
+//! // Provides the builder for DisplayInterface
+//! use display_interface_parallel_gpio::{Generic8BitBus, PGPIO8BitInterface};
+//! // Provides the builder for Display
+//! use mipidsi::Builder;
+//! // Provides the required color type
+//! use embedded_graphics::pixelcolor::Rgb666;
 //!
 //! /* Define digital output pins d0 - d7 for the parallel port as `lcd_dX` */
 //! /* Define the D/C digital output pin as `dc` */
-//! /* Define the WR and Reset digital output pins with the initial state set as High as `wr` and `rst` */
-//! 
-//! // Create the DisplayInterface from a Generic8BitBus, which is provided all the parallel port pins
-//! let bus = Generic8BitBus::new((lcd_d0, lcd_d1, lcd_d2, lcd_d3, lcd_d4, lcd_d5, lcd_d6, lcd_d7)).unwrap();
+//! /* Define the WR and Reset digital output pins with the initial state set as High as `wr` and 
+//! `rst` */
+//!
+//! // Create the DisplayInterface from a Generic8BitBus, which is made from the parallel pins
+//! let bus = Generic8BitBus::new((lcd_d0, lcd_d1, lcd_d2, 
+//!     lcd_d3, lcd_d4, lcd_d5, lcd_d6, lcd_d7)).unwrap();
 //! let di = PGPIO8BitInterface::new(bus, dc, wr);
 //!
 //! // Create the ILI9341 display driver from the display interface with the RGB666 color space
 //! let mut display = Builder::ili9341_rgb666(di)
 //!      .with_color_order(mipidsi::ColorOrder::Bgr)
 //!      .init(&mut delay, Some(rst)).unwrap();
-//! 
+//!
 //! // Clear the display to black
 //! display.clear(Rgb666::RED).unwrap();
 //! ```
@@ -66,7 +72,7 @@
 //! - [`display-interface-spi`](https://docs.rs/display-interface-spi/)
 //! - [`display-interface-parallel-gpio`](https://docs.rs/display-interface-parallel-gpio)
 //! - [`display-interface-i2c`](https://docs.rs/display-interface-i2c/)
-//! 
+//!
 //! ## Troubleshooting
 //! See [document](https://github.com/almindor/mipidsi/blob/master/docs/TROUBLESHOOTING.md)
 
@@ -131,7 +137,7 @@ where
     /// Sets display [Orientation] with mirror image parameter
     ///
     /// # Example
-    /// ```
+    /// ```rust ignore
     /// display.orientation(Orientation::Portrait(false)).unwrap();
     /// ```
     pub fn set_orientation(&mut self, orientation: Orientation) -> Result<(), Error> {
@@ -151,7 +157,7 @@ where
     /// * `color` - the color value in pixel format of the display [Model]
     ///
     /// # Example
-    /// ```
+    /// ```rust ignore
     /// display.set_pixel(100, 200, Rgb666::new(251, 188, 20)).unwrap();
     /// ```
     pub fn set_pixel(&mut self, x: u16, y: u16, color: M::ColorFormat) -> Result<(), Error> {
@@ -172,7 +178,7 @@ where
     /// * `ex` - x coordinate end
     /// * `ey` - y coordinate end
     /// * `colors` - anything that can provide `IntoIterator<Item = u16>` to iterate over pixel data
-    /// 
+    ///
     pub fn set_pixels<T>(
         &mut self,
         sx: u16,


### PR DESCRIPTION
Made this merge request as mentioned in #64.

# Why
Coming into the crate I wasn't sure where `DisplayInterface` and `Rgb565` came from, as well as which modules I needed to import. Browsing through different crate docs and looking at clippy helps you figure out all of that, but adding more, and less simplified examples saves you most of that trouble.

# Changes included
 - Amplify (and fix) existing example on docs homepage
 - Add example on docs homepage
 - Add list of `display-interface` crates that can be used to create the `DisplayInterface`
 - Add usage example to `.orientation()` and `.setpixel()`
 - Add usage example to `Builder` docs page
 - Add an `/examples` folder (Contains an example for the pi pico with the ili9341)
 
# Could be improved:
 - Missing usage example for [`display.set_pixels()`](https://docs.rs/mipidsi/latest/mipidsi/struct.Display.html#method.set_pixels) (It's not very clear what "*anything that can provide `IntoIterator<Item = u16>`*" is supposed to be)
 - Explanation on [`display.set_scroll_region()`](https://docs.rs/mipidsi/latest/mipidsi/struct.Display.html#method.set_scroll_region) isn't very extensive/clear
 - Another example on the `/examples` folder with another display, microcontroller and interface used. Could also include a more advanced drawing rather than just the whole screen being one color. A colored square would be nice. 