### PR TITLE
Add example on docs and /examples folder

### DIFF
--- a/examples/spi-ili9486-esp32-c3/.cargo/config.toml
+++ b/examples/spi-ili9486-esp32-c3/.cargo/config.toml
@@ -1,0 +1,31 @@
+[target.riscv32imc-unknown-none-elf]
+runner = "espflash flash --monitor"
+
+[build]
+rustflags = [
+  "-C", "link-arg=-Tlinkall.x",
+  # Required to obtain backtraces (e.g. when using the "esp-backtrace" crate.)
+  # NOTE: May negatively impact performance of produced code
+  "-C", "force-frame-pointers",
+
+  # comment the cfgs below if you do _not_ wish to emulate atomics.
+  # enable the atomic codegen option for RISCV
+  "-C", "target-feature=+a",
+  # tell the core library have atomics even though it's not specified in the target definition
+  "--cfg", "target_has_atomic_load_store",
+  "--cfg", 'target_has_atomic_load_store="8"',
+  "--cfg", 'target_has_atomic_load_store="16"',
+  "--cfg", 'target_has_atomic_load_store="32"',
+  "--cfg", 'target_has_atomic_load_store="ptr"',
+  # enable cas
+  "--cfg", "target_has_atomic",
+  "--cfg", 'target_has_atomic="8"',
+  "--cfg", 'target_has_atomic="16"',
+  "--cfg", 'target_has_atomic="32"',
+  "--cfg", 'target_has_atomic="ptr"',
+]
+
+target = "riscv32imc-unknown-none-elf"
+
+[unstable]
+build-std = ["core"]

--- a/examples/spi-ili9486-esp32-c3/Cargo.toml
+++ b/examples/spi-ili9486-esp32-c3/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "spi_ili9486_esp32c3"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+hal = { package = "esp32c3-hal", version = "0.10.0" }
+esp-backtrace = { version = "0.7.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
+esp-println       = { version = "0.5.0", features = ["esp32c3"] }
+embedded-graphics = "0.8.0"
+display-interface-spi = "0.4.1"
+mipidsi = "0.7.1"
+fugit = "0.3.7"

--- a/examples/spi-ili9486-esp32-c3/rust-toolchain.toml
+++ b/examples/spi-ili9486-esp32-c3/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly"
+components = ["rust-src"]
+targets = ["riscv32imc-unknown-none-elf"]

--- a/examples/spi-ili9486-esp32-c3/src/main.rs
+++ b/examples/spi-ili9486-esp32-c3/src/main.rs
@@ -1,0 +1,364 @@
+#![no_std]
+#![no_main]
+
+/* --- Needed by ESP32-c3 --- */
+use esp_backtrace as _;
+use hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    spi::{Spi, SpiMode},
+    timer::TimerGroup,
+    Delay, Rtc, IO,
+};
+/* -------------------------- */
+
+use embedded_graphics::{
+    // Provides the necessary functions to draw on the display
+    draw_target::DrawTarget,
+    // Provides colors from the Rgb565 color space
+    pixelcolor::Rgb565,
+    prelude::RgbColor,
+};
+
+// Provides the parallel port and display interface builders
+use display_interface_spi::SPIInterfaceNoCS;
+
+// Provides the Display builder
+use mipidsi::Builder;
+
+use fugit::RateExtU32;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    // Disable the RTC and TIMG watchdog timers
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt1 = timer_group1.wdt;
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    // Define the delay struct, needed for the display driver
+    let mut delay = Delay::new(&clocks);
+
+    // Define the Data/Command select pin as a digital output
+    let dc = io.pins.gpio7.into_push_pull_output();
+    // Define the reset pin as digital outputs and make it high
+    let mut rst = io.pins.gpio8.into_push_pull_output();
+    rst.set_high().unwrap();
+
+    // Define the SPI pins and create the SPI interface
+    let sck = io.pins.gpio12;
+    let miso = io.pins.gpio11;
+    let mosi = io.pins.gpio13;
+    let cs = io.pins.gpio10;
+    let spi = Spi::new(
+        peripherals.SPI2,
+        sck,
+        mosi,
+        miso,
+        cs,
+        100_u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    );
+
+    // Define the display interface with no chip select
+    let di = SPIInterfaceNoCS::new(spi, dc);
+
+    // Define the display drom the display interface and initialize it
+    let mut display = Builder::ili9486_rgb565(di)
+        .init(&mut delay, Some(rst))
+        .unwrap();
+
+    // Make the display all black
+    display.clear(Rgb565::BLACK).unwrap();
+
+    // Turn SPRITE into an array of pixels in the right colorspace
+    let sprite: [Rgb565; 256] = SPRITE.map(|(r, g, b)| Rgb565::new(r, g, b));
+
+    // Draw the 16*16 sprite on the top left corner of the screen
+    display.set_pixels(0, 0, 15, 15, sprite).unwrap();
+
+    loop {
+        // Do nothing
+    }
+}
+
+// Contains all the pixel colors for a 16*16 sprite as a 256 value array of (r, g, b) values
+const SPRITE: [(u8, u8, u8); 256] = [
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (124, 252, 0),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 191, 255),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (0, 0, 0xCD),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (75, 0, 130),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (0xff, 0, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+    (255, 69, 0),
+];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,23 @@ where
     /// * `ey` - y coordinate end
     /// * `colors` - anything that can provide `IntoIterator<Item = u16>` to iterate over pixel data
     ///
+    /// # Example
+    /// An array of `Rgb666` values is an example of something that provides `IntoIterator<Item =
+    /// u16>`.
+    ///
+    /// This example assumes `my_sprite` is a 256 value array, representing the RGB values of a 16*16 sprite
+    ///
+    /// ```rust ignore
+    /// // A 256 value array, representing a 16*16 sprite.
+    /// // Each value is a tuple with the (r, g, b) values of each pixel
+    /// let my_sprite: [(u8, u8, u8); 256] = [(255, 124, 0), (230, 215, 75) ...`
+    ///
+    /// // Turn my_sprite into an array of pixels in the right colorspace
+    /// let display_sprite: [Rgb666; 255] = your_sprite.map(|(r, g, b)| Rgb666::new(r, g, b));
+    ///
+    /// // Draw the sprite, starting at (0, 0) and ending at (15, 15)
+    /// display.set_pixels(0, 0, 15, 15 display_sprite).unwrap();
+    /// ```
     pub fn set_pixels<T>(
         &mut self,
         sx: u16,


### PR DESCRIPTION
# Why
As mentioned in #65, two improvements that could be made were adding another example project and expanding documentation on [`set_pixels()`](https://docs.rs/mipidsi/latest/mipidsi/struct.Display.html#method.set_pixels)

# Changes included
 - Adds another example to the `/examples` folder. 
   - Made for the esp32-c3
   - Using the ili9486 display with SPI
   - Shows a basic example of how[`set_pixels()`](https://docs.rs/mipidsi/latest/mipidsi/struct.Display.html#method.set_pixels) can be used
   
 - Adds an example to the [`set_pixels()`](https://docs.rs/mipidsi/latest/mipidsi/struct.Display.html#method.set_pixels) on the docs