### PR TITLE
Feat/maybe async support

### DIFF
--- a/mipidsi/Cargo.toml
+++ b/mipidsi/Cargo.toml
@@ -12,9 +12,11 @@ documentation = "https://docs.rs/mipidsi"
 rust-version = "1.61"
 
 [dependencies]
-display-interface = "0.4.1"
+display-interface = { version = "0.5.0-alpha.1", git = "https://github.com/therealprof/display-interface"}
 embedded-graphics-core = "0.4.0"
-embedded-hal = "0.2.7"
+embedded-hal = "1.0.0-rc.1"
+embedded-hal-async = { version = "1.0.0-rc.1", optional = true }
+maybe-async-cfg = "0.2"
 nb = "1.0.0"
 
 [dependencies.heapless]
@@ -22,5 +24,6 @@ optional = true
 version = "0.7.16"
 
 [features]
-default = ["batch"]
+default = ["batch", "async"]
 batch = ["heapless"]
+async = ["dep:embedded-hal-async", "display-interface/async"]

--- a/mipidsi/src/batch.rs
+++ b/mipidsi/src/batch.rs
@@ -4,7 +4,7 @@
 use crate::{models::Model, Display, Error};
 use display_interface::WriteOnlyDataCommand;
 use embedded_graphics_core::prelude::*;
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::digital::OutputPin;
 
 pub trait DrawBatch<DI, M, I>
 where

--- a/mipidsi/src/builder.rs
+++ b/mipidsi/src/builder.rs
@@ -1,7 +1,7 @@
 //! [super::Display] builder module
 
 use display_interface::WriteOnlyDataCommand;
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::Dcs, error::InitError, models::Model, ColorInversion, ColorOrder, Display, ModelOptions,
@@ -123,7 +123,7 @@ where
     /// If it wasn't provided the user needs to ensure this is the case.
     pub fn init<RST>(
         mut self,
-        delay_source: &mut impl DelayUs<u32>,
+        delay_source: &mut impl DelayUs,
         mut rst: Option<RST>,
     ) -> Result<Display<DI, MODEL, RST>, InitError<RST::Error>>
     where

--- a/mipidsi/src/error.rs
+++ b/mipidsi/src/error.rs
@@ -7,7 +7,7 @@ use display_interface::DisplayError;
 pub enum InitError<PE> {
     /// Error caused by the display interface.
     DisplayError,
-    /// Error caused by the reset pin's [`OutputPin`](embedded_hal::digital::v2::OutputPin) implementation.
+    /// Error caused by the reset pin's [`OutputPin`](embedded_hal::digital::OutputPin) implementation.
     Pin(PE),
 }
 

--- a/mipidsi/src/graphics.rs
+++ b/mipidsi/src/graphics.rs
@@ -1,7 +1,7 @@
 use embedded_graphics_core::prelude::{DrawTarget, Point, RgbColor, Size};
 use embedded_graphics_core::primitives::Rectangle;
 use embedded_graphics_core::{prelude::OriginDimensions, Pixel};
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::digital::OutputPin;
 
 use crate::dcs::BitsPerPixel;
 use crate::models::Model;

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -2,6 +2,11 @@
 // associated re-typing not supported in rust yet
 #![allow(clippy::type_complexity)]
 #![warn(missing_docs)]
+#![cfg_attr(
+    all(feature = "async"),
+    allow(incomplete_features),
+    feature(async_fn_in_trait, impl_trait_projections)
+)]
 
 //! This crate provides a generic display driver to connect to TFT displays
 //! that implement the [MIPI Display Command Set](https://www.mipi.org/specifications/display-command-set).

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -80,7 +80,7 @@ use dcs::Dcs;
 use display_interface::WriteOnlyDataCommand;
 
 pub mod error;
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::digital::OutputPin;
 pub use error::Error;
 
 pub mod options;

--- a/mipidsi/src/models.rs
+++ b/mipidsi/src/models.rs
@@ -10,12 +10,9 @@ use embedded_graphics_core::prelude::RgbColor;
 use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 #[cfg(feature = "async")]
-mod asynch {
-    pub use display_interface::AsyncWriteOnlyDataCommand;
-    pub use embedded_hal_async::delay::DelayUs as DelayUsAsync;
-}
+use display_interface::AsyncWriteOnlyDataCommand;
 #[cfg(feature = "async")]
-use asynch::*;
+use embedded_hal_async::delay::DelayUs as DelayUsAsync;
 
 // existing model implementations
 mod gc9a01;

--- a/mipidsi/src/models.rs
+++ b/mipidsi/src/models.rs
@@ -10,6 +10,8 @@ use embedded_graphics_core::prelude::RgbColor;
 use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 #[cfg(feature = "async")]
+use crate::dcs::DcsAsync;
+#[cfg(feature = "async")]
 use display_interface::AsyncWriteOnlyDataCommand;
 #[cfg(feature = "async")]
 use embedded_hal_async::delay::DelayUs as DelayUsAsync;
@@ -33,8 +35,9 @@ pub use st7789::*;
 /// Display model.
 #[maybe_async_cfg::maybe(
     idents(
-        WriteOnlyDataCommand(sync, async = "AsyncWriteOnlyDataCommand"),
+        Dcs(sync, async = "DcsAsync"),
         DelayUs(sync, async = "DelayUsAsync"),
+        WriteOnlyDataCommand(sync, async = "AsyncWriteOnlyDataCommand"),
     ),
     sync(keep_self),
     async(feature = "async")
@@ -86,5 +89,5 @@ pub trait Model {
     ///
     /// This serves as a "sane default". There can be additional variants which will be provided via
     /// helper constructors.
-    async fn default_options() -> ModelOptions;
+    fn default_options() -> ModelOptions;
 }

--- a/mipidsi/src/models/gc9a01.rs
+++ b/mipidsi/src/models/gc9a01.rs
@@ -1,6 +1,6 @@
 use display_interface::{DataFormat, WriteOnlyDataCommand};
 use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{
@@ -28,7 +28,7 @@ impl Model for GC9A01 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         let madctl = SetAddressMode::from(options);

--- a/mipidsi/src/models/gc9a01.rs
+++ b/mipidsi/src/models/gc9a01.rs
@@ -13,13 +13,33 @@ use crate::{
 
 use super::{Dcs, Model};
 
+#[cfg(feature = "async")]
+use crate::dcs::DcsAsync;
+#[cfg(feature = "async")]
+use crate::models::ModelAsync;
+#[cfg(feature = "async")]
+use display_interface::AsyncWriteOnlyDataCommand;
+#[cfg(feature = "async")]
+use embedded_hal_async::delay::DelayUs as DelayUsAsync;
+
 /// GC9A01 display in Rgb565 color mode.
+#[maybe_async_cfg::maybe(sync(keep_self), async(feature = "async"))]
 pub struct GC9A01;
 
+#[maybe_async_cfg::maybe(
+    idents(
+        Dcs(sync, async = "DcsAsync"),
+        DelayUs(sync, async = "DelayUsAsync"),
+        Model(sync, async = "ModelAsync"),
+        WriteOnlyDataCommand(sync, async = "AsyncWriteOnlyDataCommand"),
+    ),
+    sync(keep_self),
+    async(feature = "async")
+)]
 impl Model for GC9A01 {
     type ColorFormat = Rgb565;
 
-    fn init<RST, DELAY, DI>(
+    async fn init<RST, DELAY, DI>(
         &mut self,
         dcs: &mut Dcs<DI>,
         delay: &mut DELAY,
@@ -34,111 +54,123 @@ impl Model for GC9A01 {
         let madctl = SetAddressMode::from(options);
 
         match rst {
-            Some(ref mut rst) => self.hard_reset(rst, delay)?,
-            None => dcs.write_command(SoftReset)?,
+            Some(ref mut rst) => self.hard_reset(rst, delay).await?,
+            None => dcs.write_command(SoftReset).await?,
         }
-        delay.delay_us(200_000);
+        delay.delay_us(200_000).await;
 
-        dcs.write_raw(0xEF, &[])?; // inter register enable 2
-        dcs.write_raw(0xEB, &[0x14])?;
-        dcs.write_raw(0xFE, &[])?; // inter register enable 1
-        dcs.write_raw(0xEF, &[])?; // inter register enable 2
-        dcs.write_raw(0xEB, &[0x14])?;
+        dcs.write_raw(0xEF, &[]).await?; // inter register enable 2
+        dcs.write_raw(0xEB, &[0x14]).await?;
+        dcs.write_raw(0xFE, &[]).await?; // inter register enable 1
+        dcs.write_raw(0xEF, &[]).await?; // inter register enable 2
+        dcs.write_raw(0xEB, &[0x14]).await?;
 
-        dcs.write_raw(0x84, &[0x40])?;
-        dcs.write_raw(0x85, &[0xFF])?;
-        dcs.write_raw(0x86, &[0xFF])?;
-        dcs.write_raw(0x87, &[0xFF])?;
-        dcs.write_raw(0x88, &[0x0A])?;
-        dcs.write_raw(0x89, &[0x21])?;
-        dcs.write_raw(0x8A, &[0x00])?;
-        dcs.write_raw(0x8B, &[0x80])?;
-        dcs.write_raw(0x8C, &[0x01])?;
-        dcs.write_raw(0x8D, &[0x01])?;
-        dcs.write_raw(0x8E, &[0xFF])?;
-        dcs.write_raw(0x8F, &[0xFF])?;
+        dcs.write_raw(0x84, &[0x40]).await?;
+        dcs.write_raw(0x85, &[0xFF]).await?;
+        dcs.write_raw(0x86, &[0xFF]).await?;
+        dcs.write_raw(0x87, &[0xFF]).await?;
+        dcs.write_raw(0x88, &[0x0A]).await?;
+        dcs.write_raw(0x89, &[0x21]).await?;
+        dcs.write_raw(0x8A, &[0x00]).await?;
+        dcs.write_raw(0x8B, &[0x80]).await?;
+        dcs.write_raw(0x8C, &[0x01]).await?;
+        dcs.write_raw(0x8D, &[0x01]).await?;
+        dcs.write_raw(0x8E, &[0xFF]).await?;
+        dcs.write_raw(0x8F, &[0xFF]).await?;
 
-        dcs.write_raw(0xB6, &[0x00, 0x20])?; // display function control
+        dcs.write_raw(0xB6, &[0x00, 0x20]).await?; // display function control
 
-        dcs.write_command(madctl)?; // set memory data access control, Top -> Bottom, RGB, Left -> Right
+        dcs.write_command(madctl).await?; // set memory data access control, Top -> Bottom, RGB, Left -> Right
 
         let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
-        dcs.write_command(SetPixelFormat::new(pf))?; // set interface pixel format, 16bit pixel into frame memory
+        dcs.write_command(SetPixelFormat::new(pf)).await?; // set interface pixel format, 16bit pixel into frame memory
 
-        dcs.write_raw(0x90, &[0x08, 0x08, 0x08, 0x08])?;
-        dcs.write_raw(0xBD, &[0x06])?;
-        dcs.write_raw(0xBC, &[0x00])?;
-        dcs.write_raw(0xFF, &[0x60, 0x01, 0x04])?;
+        dcs.write_raw(0x90, &[0x08, 0x08, 0x08, 0x08]).await?;
+        dcs.write_raw(0xBD, &[0x06]).await?;
+        dcs.write_raw(0xBC, &[0x00]).await?;
+        dcs.write_raw(0xFF, &[0x60, 0x01, 0x04]).await?;
 
-        dcs.write_raw(0xC3, &[0x13])?; // power control 2
-        dcs.write_raw(0xC4, &[0x13])?; // power control 3
-        dcs.write_raw(0xC9, &[0x22])?; // power control 4
+        dcs.write_raw(0xC3, &[0x13]).await?; // power control 2
+        dcs.write_raw(0xC4, &[0x13]).await?; // power control 3
+        dcs.write_raw(0xC9, &[0x22]).await?; // power control 4
 
-        dcs.write_raw(0xBE, &[0x11])?;
-        dcs.write_raw(0xE1, &[0x10, 0x0E])?;
-        dcs.write_raw(0xDF, &[0x20, 0x0c, 0x02])?;
+        dcs.write_raw(0xBE, &[0x11]).await?;
+        dcs.write_raw(0xE1, &[0x10, 0x0E]).await?;
+        dcs.write_raw(0xDF, &[0x20, 0x0c, 0x02]).await?;
 
-        dcs.write_raw(0xF0, &[0x45, 0x09, 0x08, 0x08, 0x26, 0x2A])?; // gamma 1
-        dcs.write_raw(0xF1, &[0x43, 0x70, 0x72, 0x36, 0x37, 0x6f])?; // gamma 2
-        dcs.write_raw(0xF2, &[0x45, 0x09, 0x08, 0x08, 0x26, 0x2A])?; // gamma 3
-        dcs.write_raw(0xF3, &[0x43, 0x70, 0x72, 0x36, 0x37, 0x6f])?; // gamma 4
+        dcs.write_raw(0xF0, &[0x45, 0x09, 0x08, 0x08, 0x26, 0x2A])
+            .await?; // gamma 1
+        dcs.write_raw(0xF1, &[0x43, 0x70, 0x72, 0x36, 0x37, 0x6f])
+            .await?; // gamma 2
+        dcs.write_raw(0xF2, &[0x45, 0x09, 0x08, 0x08, 0x26, 0x2A])
+            .await?; // gamma 3
+        dcs.write_raw(0xF3, &[0x43, 0x70, 0x72, 0x36, 0x37, 0x6f])
+            .await?; // gamma 4
 
-        dcs.write_raw(0xED, &[0x18, 0x0B])?;
-        dcs.write_raw(0xAE, &[0x77])?;
-        dcs.write_raw(0xCD, &[0x63])?;
+        dcs.write_raw(0xED, &[0x18, 0x0B]).await?;
+        dcs.write_raw(0xAE, &[0x77]).await?;
+        dcs.write_raw(0xCD, &[0x63]).await?;
 
         dcs.write_raw(
             0x70,
             &[0x07, 0x07, 0x04, 0x0E, 0x0F, 0x09, 0x07, 0x08, 0x03],
-        )?;
+        )
+        .await?;
 
-        dcs.write_raw(0xE8, &[0x34])?; // framerate
+        dcs.write_raw(0xE8, &[0x34]).await?; // framerate
 
         dcs.write_raw(
             0x62,
             &[
                 0x18, 0x0D, 0x71, 0xED, 0x70, 0x70, 0x18, 0x0F, 0x71, 0xEF, 0x70, 0x70,
             ],
-        )?;
+        )
+        .await?;
         dcs.write_raw(
             0x63,
             &[
                 0x18, 0x11, 0x71, 0xF1, 0x70, 0x70, 0x18, 0x13, 0x71, 0xF3, 0x70, 0x70,
             ],
-        )?;
-        dcs.write_raw(0x64, &[0x28, 0x29, 0xF1, 0x01, 0xF1, 0x00, 0x07])?;
+        )
+        .await?;
+        dcs.write_raw(0x64, &[0x28, 0x29, 0xF1, 0x01, 0xF1, 0x00, 0x07])
+            .await?;
         dcs.write_raw(
             0x66,
             &[0x3C, 0x00, 0xCD, 0x67, 0x45, 0x45, 0x10, 0x00, 0x00, 0x00],
-        )?;
+        )
+        .await?;
         dcs.write_raw(
             0x67,
             &[0x00, 0x3C, 0x00, 0x00, 0x00, 0x01, 0x54, 0x10, 0x32, 0x98],
-        )?;
+        )
+        .await?;
 
-        dcs.write_raw(0x74, &[0x10, 0x85, 0x80, 0x00, 0x00, 0x4E, 0x00])?;
-        dcs.write_raw(0x98, &[0x3e, 0x07])?;
+        dcs.write_raw(0x74, &[0x10, 0x85, 0x80, 0x00, 0x00, 0x4E, 0x00])
+            .await?;
+        dcs.write_raw(0x98, &[0x3e, 0x07]).await?;
 
-        dcs.write_command(SetInvertMode(options.invert_colors))?; // set color inversion
+        dcs.write_command(SetInvertMode(options.invert_colors))
+            .await?; // set color inversion
 
-        dcs.write_command(ExitSleepMode)?; // turn off sleep
-        delay.delay_us(120_000);
+        dcs.write_command(ExitSleepMode).await?; // turn off sleep
+        delay.delay_us(120_000).await;
 
-        dcs.write_command(SetDisplayOn)?; // turn on display
+        dcs.write_command(SetDisplayOn).await?; // turn on display
 
         Ok(madctl)
     }
 
-    fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+    async fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
     where
         DI: WriteOnlyDataCommand,
         I: IntoIterator<Item = Self::ColorFormat>,
     {
-        dcs.write_command(WriteMemoryStart)?;
+        dcs.write_command(WriteMemoryStart).await?;
         let mut iter = colors.into_iter().map(|c| c.into_storage());
 
         let buf = DataFormat::U16BEIter(&mut iter);
-        dcs.di.send_data(buf)?;
+        dcs.di.send_data(buf).await?;
         Ok(())
     }
 

--- a/mipidsi/src/models/ili9341.rs
+++ b/mipidsi/src/models/ili9341.rs
@@ -1,6 +1,6 @@
 use display_interface::WriteOnlyDataCommand;
 use embedded_graphics_core::pixelcolor::{Rgb565, Rgb666};
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{BitsPerPixel, Dcs, PixelFormat, SetAddressMode, SoftReset},
@@ -27,7 +27,7 @@ impl Model for ILI9341Rgb565 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {
@@ -64,7 +64,7 @@ impl Model for ILI9341Rgb666 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {

--- a/mipidsi/src/models/ili9342c.rs
+++ b/mipidsi/src/models/ili9342c.rs
@@ -1,6 +1,6 @@
 use display_interface::WriteOnlyDataCommand;
 use embedded_graphics_core::pixelcolor::{Rgb565, Rgb666};
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{BitsPerPixel, Dcs, PixelFormat, SetAddressMode, SoftReset},
@@ -27,7 +27,7 @@ impl Model for ILI9342CRgb565 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {
@@ -64,7 +64,7 @@ impl Model for ILI9342CRgb666 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {

--- a/mipidsi/src/models/ili934x.rs
+++ b/mipidsi/src/models/ili934x.rs
@@ -1,6 +1,6 @@
 use display_interface::{DataFormat, WriteOnlyDataCommand};
 use embedded_graphics_core::pixelcolor::{IntoStorage, Rgb565, Rgb666, RgbColor};
-use embedded_hal::blocking::delay::DelayUs;
+use embedded_hal::delay::DelayUs;
 
 use crate::{
     dcs::{
@@ -18,7 +18,7 @@ pub fn init_common<DELAY, DI>(
     pixel_format: PixelFormat,
 ) -> Result<SetAddressMode, Error>
 where
-    DELAY: DelayUs<u32>,
+    DELAY: DelayUs,
     DI: WriteOnlyDataCommand,
 {
     let madctl = SetAddressMode::from(options);

--- a/mipidsi/src/models/ili9486.rs
+++ b/mipidsi/src/models/ili9486.rs
@@ -3,7 +3,7 @@ use embedded_graphics_core::{
     pixelcolor::{Rgb565, Rgb666},
     prelude::{IntoStorage, RgbColor},
 };
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{
@@ -34,7 +34,7 @@ impl Model for ILI9486Rgb565 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {
@@ -76,7 +76,7 @@ impl Model for ILI9486Rgb666 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {
@@ -160,7 +160,7 @@ fn init_common<DELAY, DI>(
     pixel_format: PixelFormat,
 ) -> Result<SetAddressMode, Error>
 where
-    DELAY: DelayUs<u32>,
+    DELAY: DelayUs,
     DI: WriteOnlyDataCommand,
 {
     let madctl = SetAddressMode::from(options);

--- a/mipidsi/src/models/st7735s.rs
+++ b/mipidsi/src/models/st7735s.rs
@@ -1,6 +1,6 @@
 use display_interface::{DataFormat, WriteOnlyDataCommand};
 use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{
@@ -28,7 +28,7 @@ impl Model for ST7735s {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         let madctl = SetAddressMode::from(options);

--- a/mipidsi/src/models/st7789.rs
+++ b/mipidsi/src/models/st7789.rs
@@ -1,6 +1,6 @@
 use display_interface::{DataFormat, WriteOnlyDataCommand};
 use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{
@@ -33,7 +33,7 @@ impl Model for ST7789 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         let madctl = SetAddressMode::from(options);


### PR DESCRIPTION
Here is how it would look if we used [maybe-async-cfg](https://crates.io/crates/maybe-async-cfg) to handle sync and async code, see the doc for macro [here](https://docs.rs/maybe-async-cfg/0.2.3/maybe_async_cfg/attr.maybe.html).

 Mainly we just compile and change the identifier for the async ones and we end up with a async and sync variant of each trait and struct. Ex: The lib would have an `DisplayAsync` and `Display` struct. 
 
 I havent completed all the impl for all the displays since I wanted your feedback beforehand and didn't want to overload the PR with noise. Currently, only the `GC9A01` is implemented but it would be pretty much the same for all models.

Note that I've updated `embedded-hal` and I'm currently using the git version of `display-interface` since the release with async support was not created yet.