### PR TITLE
Feat/mipidsi async support

### DIFF
--- a/mipidsi-async/Cargo.toml
+++ b/mipidsi-async/Cargo.toml
@@ -12,9 +12,12 @@ documentation = "https://docs.rs/mipidsi"
 rust-version = "1.61"
 
 [dependencies]
-display-interface = "0.4.1"
+display-interface = { version = "0.5.0-alpha.1", git = "https://github.com/therealprof/display-interface", features = ["async"] }
 embedded-graphics-core = "0.4.0"
-embedded-hal = "0.2.7"
+embedded-hal = "1.0.0-rc.1"
+embedded-hal-async = { version = "1.0.0-rc.1" }
+maybe-async-cfg = "0.2"
+mipidsi = { version = "0.7", path = "../mipidsi" }
 nb = "1.0.0"
 
 [dependencies.heapless]

--- a/mipidsi-async/Cargo.toml
+++ b/mipidsi-async/Cargo.toml
@@ -25,4 +25,4 @@ version = "0.7.16"
 
 [features]
 default = ["batch"]
-batch = ["heapless"]
+batch = ["heapless", "mipidsi/batch"]

--- a/mipidsi-async/Cargo.toml
+++ b/mipidsi-async/Cargo.toml
@@ -16,7 +16,6 @@ display-interface = { version = "0.5.0-alpha.1", git = "https://github.com/there
 embedded-graphics-core = "0.4.0"
 embedded-hal = "1.0.0-rc.1"
 embedded-hal-async = { version = "1.0.0-rc.1" }
-maybe-async-cfg = "0.2"
 mipidsi = { version = "0.7", path = "../mipidsi" }
 nb = "1.0.0"
 

--- a/mipidsi-async/src/batch.rs
+++ b/mipidsi-async/src/batch.rs
@@ -1,0 +1,55 @@
+//! Original code from: [this repo](https://github.com/lupyuen/piet-embedded/blob/master/piet-embedded-graphics/src/batch.rs)
+//! Batch the pixels to be rendered into Pixel Rows and Pixel Blocks (contiguous Pixel Rows).
+//! This enables the pixels to be rendered efficiently as Pixel Blocks, which may be transmitted in a single Non-Blocking SPI request.
+use crate::{models::Model, Display, Error};
+use display_interface::AsyncWriteOnlyDataCommand;
+use embedded_graphics_core::prelude::*;
+use embedded_hal::digital::OutputPin;
+use mipidsi::batch::{to_blocks, to_rows, PixelBlock};
+
+pub trait DrawBatch<DI, M, I>
+where
+    DI: AsyncWriteOnlyDataCommand,
+    M: Model,
+    I: IntoIterator<Item = Pixel<M::ColorFormat>>,
+{
+    async fn draw_batch(&mut self, item_pixels: I) -> Result<(), Error>;
+}
+
+impl<DI, M, RST, I> DrawBatch<DI, M, I> for Display<DI, M, RST>
+where
+    DI: AsyncWriteOnlyDataCommand,
+    M: Model,
+    I: IntoIterator<Item = Pixel<M::ColorFormat>>,
+    RST: OutputPin,
+{
+    async fn draw_batch(&mut self, item_pixels: I) -> Result<(), Error> {
+        //  Get the pixels for the item to be rendered.
+        let pixels = item_pixels.into_iter();
+        //  Batch the pixels into Pixel Rows.
+        let rows = to_rows(pixels);
+        //  Batch the Pixel Rows into Pixel Blocks.
+        let blocks = to_blocks(rows);
+        //  For each Pixel Block...
+        for PixelBlock {
+            x_left,
+            x_right,
+            y_top,
+            y_bottom,
+            colors,
+            ..
+        } in blocks
+        {
+            //  Render the Pixel Block.
+            self.set_pixels(x_left, y_top, x_right, y_bottom, colors)
+                .await?;
+
+            //  Dump out the Pixel Blocks for the square in test_display()
+            /* if x_left >= 60 && x_left <= 150 && x_right >= 60 && x_right <= 150 && y_top >= 60 && y_top <= 150 && y_bottom >= 60 && y_bottom <= 150 {
+                console::print("pixel block ("); console::printint(x_left as i32); console::print(", "); console::printint(y_top as i32); ////
+                console::print("), ("); console::printint(x_right as i32); console::print(", "); console::printint(y_bottom as i32); console::print(")\n"); ////
+            } */
+        }
+        Ok(())
+    }
+}

--- a/mipidsi-async/src/builder.rs
+++ b/mipidsi-async/src/builder.rs
@@ -1,0 +1,146 @@
+use display_interface::AsyncWriteOnlyDataCommand;
+use embedded_hal::digital::OutputPin;
+use embedded_hal_async::delay::DelayUs;
+use mipidsi::{
+    error::InitError, ColorInversion, ColorOrder, ModelOptions, Orientation, RefreshOrder,
+};
+
+use crate::{dcs::Dcs, models::Model, Display};
+
+/// Builder for [Display] instances.
+///
+/// Exposes all possible display options.
+///
+///
+/// ## Example
+/// ```rust ignore
+/// let mut display = Builder::ili9342c_rgb565(di)
+///     .with_color_order(ColorOrder::Bgr);
+///     .with_display_size(320, 240);
+///     .init(&mut delay, Some(rst)).unwrap();
+/// ```
+pub struct Builder<DI, MODEL>
+where
+    DI: AsyncWriteOnlyDataCommand,
+    MODEL: Model,
+{
+    di: DI,
+    model: MODEL,
+    options: ModelOptions,
+}
+
+impl<DI, MODEL> Builder<DI, MODEL>
+where
+    DI: AsyncWriteOnlyDataCommand,
+    MODEL: Model,
+{
+    ///
+    /// Constructs a new builder from given [AsyncWriteOnlyDataCommand], [Model]
+    /// and [ModelOptions]. For use by [Model] helpers, not public
+    ///
+    pub(crate) fn new(di: DI, model: MODEL, options: ModelOptions) -> Self {
+        Self { di, model, options }
+    }
+
+    ///
+    /// Constructs a new builder for given [Model] using the model's
+    /// `default_options`
+    ///
+    pub fn with_model(di: DI, model: MODEL) -> Self {
+        Self {
+            di,
+            model,
+            options: MODEL::default_options(),
+        }
+    }
+
+    ///
+    /// Sets the invert color flag
+    ///
+    pub fn with_invert_colors(mut self, color_inversion: ColorInversion) -> Self {
+        self.options.invert_colors = color_inversion;
+        self
+    }
+
+    ///
+    /// Sets the [ColorOrder]
+    ///
+    pub fn with_color_order(mut self, color_order: ColorOrder) -> Self {
+        self.options.color_order = color_order;
+        self
+    }
+
+    ///
+    /// Sets the [Orientation]
+    ///
+    pub fn with_orientation(mut self, orientation: Orientation) -> Self {
+        self.options.orientation = orientation;
+        self
+    }
+
+    ///
+    /// Sets refresh order
+    ///
+    pub fn with_refresh_order(mut self, refresh_order: RefreshOrder) -> Self {
+        self.options.refresh_order = refresh_order;
+        self
+    }
+
+    ///
+    /// Sets the display size
+    ///
+    pub fn with_display_size(mut self, width: u16, height: u16) -> Self {
+        self.options.display_size = (width, height);
+        self
+    }
+
+    ///
+    /// Sets the framebuffer size
+    ///
+    pub fn with_framebuffer_size(mut self, width: u16, height: u16) -> Self {
+        self.options.framebuffer_size = (width, height);
+        self
+    }
+
+    ///
+    /// Sets the window offset handler
+    ///
+    pub fn with_window_offset_handler(
+        mut self,
+        window_offset_handler: fn(_: &ModelOptions) -> (u16, u16),
+    ) -> Self {
+        self.options.window_offset_handler = window_offset_handler;
+        self
+    }
+
+    ///
+    /// Consumes the builder to create a new [Display] with an optional reset [OutputPin].
+    /// Blocks using the provided [DelayUs] `delay_source` to perform the display initialization.
+    ///
+    /// ### WARNING
+    /// The reset pin needs to be in *high* state in order for the display to operate.
+    /// If it wasn't provided the user needs to ensure this is the case.
+    pub async fn init<RST>(
+        mut self,
+        delay_source: &mut impl DelayUs,
+        mut rst: Option<RST>,
+    ) -> Result<Display<DI, MODEL, RST>, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+    {
+        let mut dcs = Dcs::write_only(self.di);
+        let madctl = self
+            .model
+            .init(&mut dcs, delay_source, &self.options, &mut rst)
+            .await?;
+        let display = Display {
+            dcs,
+            model: self.model,
+            rst,
+            options: self.options,
+            madctl,
+        };
+
+        Ok(display)
+    }
+}

--- a/mipidsi-async/src/dcs.rs
+++ b/mipidsi-async/src/dcs.rs
@@ -1,0 +1,75 @@
+//! MIPI DCS commands.
+
+use display_interface::DataFormat;
+
+use display_interface::AsyncWriteOnlyDataCommand;
+
+use mipidsi::Error;
+
+/// Common trait for DCS commands.
+///
+/// The methods in this traits are used to convert a DCS command into bytes.
+pub trait DcsCommand {
+    /// Returns the instruction code.
+    fn instruction(&self) -> u8;
+
+    /// Fills the given buffer with the command parameters.
+    fn fill_params_buf(&self, buffer: &mut [u8]) -> Result<usize, Error>;
+}
+
+/// Wrapper around [`WriteOnlyDataCommand`] with support for writing DCS commands.
+///
+/// Commands which are part of the manufacturer independent user command set can be sent to the
+/// display by using the [`write_command`](Self::write_command) method with one of the command types
+/// in this module.
+///
+/// All other commands, which do not have an associated type in this module, can be sent using
+/// the [`write_raw`](Self::write_raw) method. The underlying display interface is also accessible
+/// using the public [`di`](Self::di) field.
+pub struct Dcs<DI> {
+    /// Display interface instance.
+    pub di: DI,
+}
+
+impl<DI> Dcs<DI>
+where
+    DI: AsyncWriteOnlyDataCommand,
+{
+    /// Creates a new [Dcs] instance from a display interface.
+    pub fn write_only(di: DI) -> Self {
+        Self { di }
+    }
+
+    /// Releases the display interface.
+    pub fn release(self) -> DI {
+        self.di
+    }
+
+    /// Sends a DCS command to the display interface.
+    pub async fn write_command(&mut self, command: impl DcsCommand) -> Result<(), Error> {
+        let mut param_bytes: [u8; 16] = [0; 16];
+        let n = command.fill_params_buf(&mut param_bytes)?;
+        self.write_raw(command.instruction(), &param_bytes[..n])
+            .await
+    }
+
+    /// Sends a raw command with the given `instruction` to the display interface.
+    ///
+    /// The `param_bytes` slice can contain the instruction parameters, which are sent as data after
+    /// the instruction code was sent. If no parameters are required an empty slice can be passed to
+    /// this method.
+    ///
+    /// This method is intended to be used for sending commands which are not part of the MIPI DCS
+    /// user command set. Use [`write_command`](Self::write_command) for commands in the user
+    /// command set.
+    pub async fn write_raw(&mut self, instruction: u8, param_bytes: &[u8]) -> Result<(), Error> {
+        self.di
+            .send_commands(DataFormat::U8(&[instruction]))
+            .await?;
+
+        if !param_bytes.is_empty() {
+            self.di.send_data(DataFormat::U8(param_bytes)).await?; // TODO: empty guard?
+        }
+        Ok(())
+    }
+}

--- a/mipidsi-async/src/dcs.rs
+++ b/mipidsi-async/src/dcs.rs
@@ -4,10 +4,10 @@ use display_interface::DataFormat;
 
 use display_interface::AsyncWriteOnlyDataCommand;
 pub use mipidsi::dcs::{
-    DcsCommand, EnterIdleMode, EnterNormalMode, EnterPartialMode, EnterSleepMode, ExitIdleMode,
-    ExitSleepMode, SetAddressMode, SetColumnAddress, SetDisplayOff, SetDisplayOn, SetInvertMode,
-    SetPageAddress, SetPixelFormat, SetScrollArea, SetScrollStart, SetTearingEffect, SoftReset,
-    WriteMemoryStart,
+    BitsPerPixel, DcsCommand, EnterIdleMode, EnterNormalMode, EnterPartialMode, EnterSleepMode,
+    ExitIdleMode, ExitSleepMode, PixelFormat, SetAddressMode, SetColumnAddress, SetDisplayOff,
+    SetDisplayOn, SetInvertMode, SetPageAddress, SetPixelFormat, SetScrollArea, SetScrollStart,
+    SetTearingEffect, SoftReset, WriteMemoryStart,
 };
 
 use mipidsi::Error;

--- a/mipidsi-async/src/dcs.rs
+++ b/mipidsi-async/src/dcs.rs
@@ -3,19 +3,14 @@
 use display_interface::DataFormat;
 
 use display_interface::AsyncWriteOnlyDataCommand;
+pub use mipidsi::dcs::{
+    DcsCommand, EnterIdleMode, EnterNormalMode, EnterPartialMode, EnterSleepMode, ExitIdleMode,
+    ExitSleepMode, SetAddressMode, SetColumnAddress, SetDisplayOff, SetDisplayOn, SetInvertMode,
+    SetPageAddress, SetPixelFormat, SetScrollArea, SetScrollStart, SetTearingEffect, SoftReset,
+    WriteMemoryStart,
+};
 
 use mipidsi::Error;
-
-/// Common trait for DCS commands.
-///
-/// The methods in this traits are used to convert a DCS command into bytes.
-pub trait DcsCommand {
-    /// Returns the instruction code.
-    fn instruction(&self) -> u8;
-
-    /// Fills the given buffer with the command parameters.
-    fn fill_params_buf(&self, buffer: &mut [u8]) -> Result<usize, Error>;
-}
 
 /// Wrapper around [`WriteOnlyDataCommand`] with support for writing DCS commands.
 ///

--- a/mipidsi-async/src/lib.rs
+++ b/mipidsi-async/src/lib.rs
@@ -1,1 +1,7 @@
+#![allow(incomplete_features)]
+#![feature(async_fn_in_trait, impl_trait_projections)]
+
 // TODO
+pub use mipidsi::Error;
+pub mod dcs;
+pub mod models;

--- a/mipidsi-async/src/lib.rs
+++ b/mipidsi-async/src/lib.rs
@@ -84,18 +84,13 @@ use display_interface::AsyncWriteOnlyDataCommand;
 
 use embedded_hal::digital::OutputPin;
 
-// pub mod options;
-// pub use options::*;
-
 mod builder;
 pub use builder::Builder;
 
 use models::Model;
 
-// mod graphics;
-
 #[cfg(feature = "batch")]
-mod batch;
+pub mod batch;
 
 ///
 /// Display driver to connect to TFT displays.

--- a/mipidsi-async/src/lib.rs
+++ b/mipidsi-async/src/lib.rs
@@ -1,7 +1,266 @@
+//! This crate provides a generic display driver to connect to TFT displays
+//! that implement the [MIPI Display Command Set](https://www.mipi.org/specifications/display-command-set).
+//!
+//! Uses [display_interface](https://crates.io/crates/display-interface) to talk to the hardware via transports.
+//!
+//! An optional batching of draws is supported via the `batch` feature (default on)
+//!
+//! ### List of supported models
+//!
+//! * ST7789
+//! * ST7735
+//! * ILI9486
+//! * ILI9341
+//! * ILI9342C
+//!
+//! ## Examples
+//! **For the ili9486 display, using the SPI interface with no chip select:**
+//! ```rust ignore
+//! use display_interface_spi::SPIInterfaceNoCS;    // Provides the builder for DisplayInterface
+//! use mipidsi::Builder;                           // Provides the builder for Display
+//! use embedded_graphics::pixelcolor::Rgb666;      // Provides the required color type
+//!
+//! /* Define the SPI interface as the variable `spi` */
+//! /* Define the DC digital output pin as the variable `dc` */
+//! /* Define the Reset digital output pin as the variable `rst` */
+//!
+//! // Create a DisplayInterface from SPI and DC pin, with no manual CS control
+//! let di = SPIInterfaceNoCS::new(spi, dc);
+//!
+//! // Create the ILI9486 display driver from the display interface and optional RST pin
+//! let mut display = Builder::ili9486(di)
+//!     .init(&mut delay, Some(rst)).unwrap();
+//!
+//! // Clear the display to black
+//! display.clear(Rgb666::BLACK).unwrap();
+//! ```
+//!
+//! **For the ili9341 display, using the Parallel port, with the RGB666 color space and the Bgr
+//! color order:**
+//! ```rust ignore
+//! // Provides the builder for DisplayInterface
+//! use display_interface_parallel_gpio::{Generic8BitBus, PGPIO8BitInterface};
+//! // Provides the builder for Display
+//! use mipidsi::Builder;
+//! // Provides the required color type
+//! use embedded_graphics::pixelcolor::Rgb666;
+//!
+//! /* Define digital output pins d0 - d7 for the parallel port as `lcd_dX` */
+//! /* Define the D/C digital output pin as `dc` */
+//! /* Define the WR and Reset digital output pins with the initial state set as High as `wr` and
+//! `rst` */
+//!
+//! // Create the DisplayInterface from a Generic8BitBus, which is made from the parallel pins
+//! let bus = Generic8BitBus::new((lcd_d0, lcd_d1, lcd_d2,
+//!     lcd_d3, lcd_d4, lcd_d5, lcd_d6, lcd_d7)).unwrap();
+//! let di = PGPIO8BitInterface::new(bus, dc, wr);
+//!
+//! // Create the ILI9341 display driver from the display interface with the RGB666 color space
+//! let mut display = Builder::ili9341_rgb666(di)
+//!      .with_color_order(mipidsi::ColorOrder::Bgr)
+//!      .init(&mut delay, Some(rst)).unwrap();
+//!
+//! // Clear the display to black
+//! display.clear(Rgb666::RED).unwrap();
+//! ```
+//! Use the appropiate display interface crate for your needs:
+//! - [`display-interface-spi`](https://docs.rs/display-interface-spi/)
+//! - [`display-interface-parallel-gpio`](https://docs.rs/display-interface-parallel-gpio)
+//! - [`display-interface-i2c`](https://docs.rs/display-interface-i2c/)
+//!
+//! ## Troubleshooting
+//! See [document](https://github.com/almindor/mipidsi/blob/master/docs/TROUBLESHOOTING.md)
 #![allow(incomplete_features)]
 #![feature(async_fn_in_trait, impl_trait_projections)]
 
-// TODO
+pub use mipidsi::options;
+pub use mipidsi::options::*;
 pub use mipidsi::Error;
 pub mod dcs;
 pub mod models;
+
+use dcs::Dcs;
+use display_interface::AsyncWriteOnlyDataCommand;
+
+use embedded_hal::digital::OutputPin;
+
+// pub mod options;
+// pub use options::*;
+
+mod builder;
+pub use builder::Builder;
+
+use models::Model;
+
+// mod graphics;
+
+// #[cfg(feature = "batch")]
+// mod batch;
+
+///
+/// Display driver to connect to TFT displays.
+///
+pub struct Display<DI, MODEL, RST>
+where
+    DI: AsyncWriteOnlyDataCommand,
+    MODEL: Model,
+    RST: OutputPin,
+{
+    // DCS provider
+    dcs: Dcs<DI>,
+    // Model
+    model: MODEL,
+    // Reset pin
+    rst: Option<RST>,
+    // Model Options, includes current orientation
+    options: ModelOptions,
+    // Current MADCTL value copy for runtime updates
+    madctl: dcs::SetAddressMode,
+}
+
+impl<DI, M, RST> Display<DI, M, RST>
+where
+    DI: AsyncWriteOnlyDataCommand,
+    M: Model,
+    RST: OutputPin,
+{
+    ///
+    /// Returns currently set [Orientation]
+    ///
+    pub fn orientation(&self) -> Orientation {
+        self.options.orientation()
+    }
+
+    ///
+    /// Sets display [Orientation] with mirror image parameter
+    ///
+    /// # Example
+    /// ```rust ignore
+    /// display.orientation(Orientation::Portrait(false)).unwrap();
+    /// ```
+    pub async fn set_orientation(&mut self, orientation: Orientation) -> Result<(), Error> {
+        self.madctl = self.madctl.with_orientation(orientation); // set orientation
+        self.dcs.write_command(self.madctl).await?;
+
+        Ok(())
+    }
+
+    ///
+    /// Sets a pixel color at the given coords.
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - x coordinate
+    /// * `y` - y coordinate
+    /// * `color` - the color value in pixel format of the display [Model]
+    ///
+    /// # Example
+    /// ```rust ignore
+    /// display.set_pixel(100, 200, Rgb666::new(251, 188, 20)).unwrap();
+    /// ```
+    pub async fn set_pixel(&mut self, x: u16, y: u16, color: M::ColorFormat) -> Result<(), Error> {
+        self.set_address_window(x, y, x, y).await?;
+        self.model
+            .write_pixels(&mut self.dcs, core::iter::once(color))
+            .await?;
+
+        Ok(())
+    }
+
+    ///
+    /// Sets pixel colors in a rectangular region.
+    ///
+    /// The color values from the `colors` iterator will be drawn to the given region starting
+    /// at the top left corner and continuing, row first, to the bottom right corner. No bounds
+    /// checking is performed on the `colors` iterator and drawing will wrap around if the
+    /// iterator returns more color values than the number of pixels in the given region.
+    ///
+    /// This is a low level function, which isn't intended to be used in regular user code.
+    /// Consider using the [`fill_contiguous`](https://docs.rs/embedded-graphics/latest/embedded_graphics/draw_target/trait.DrawTarget.html#method.fill_contiguous)
+    /// function from the `embedded-graphics` crate as an alternative instead.
+    ///
+    /// # Arguments
+    ///
+    /// * `sx` - x coordinate start
+    /// * `sy` - y coordinate start
+    /// * `ex` - x coordinate end
+    /// * `ey` - y coordinate end
+    /// * `colors` - anything that can provide `IntoIterator<Item = u16>` to iterate over pixel data
+    pub async fn set_pixels<T>(
+        &mut self,
+        sx: u16,
+        sy: u16,
+        ex: u16,
+        ey: u16,
+        colors: T,
+    ) -> Result<(), Error>
+    where
+        T: IntoIterator<Item = M::ColorFormat>,
+    {
+        self.set_address_window(sx, sy, ex, ey).await?;
+        self.model.write_pixels(&mut self.dcs, colors).await?;
+
+        Ok(())
+    }
+
+    ///
+    /// Sets scroll region
+    /// # Arguments
+    ///
+    /// * `tfa` - Top fixed area
+    /// * `vsa` - Vertical scrolling area
+    /// * `bfa` - Bottom fixed area
+    ///
+    pub async fn set_scroll_region(&mut self, tfa: u16, vsa: u16, bfa: u16) -> Result<(), Error> {
+        let vscrdef = dcs::SetScrollArea::new(tfa, vsa, bfa);
+        self.dcs.write_command(vscrdef).await
+    }
+
+    ///
+    /// Sets scroll offset "shifting" the displayed picture
+    /// # Arguments
+    ///
+    /// * `offset` - scroll offset in pixels
+    ///
+    pub async fn set_scroll_offset(&mut self, offset: u16) -> Result<(), Error> {
+        let vscad = dcs::SetScrollStart::new(offset);
+        self.dcs.write_command(vscad).await
+    }
+
+    ///
+    /// Release resources allocated to this driver back.
+    /// This returns the display interface, reset pin and and the model deconstructing the driver.
+    ///
+    pub fn release(self) -> (DI, M, Option<RST>) {
+        (self.dcs.release(), self.model, self.rst)
+    }
+
+    // Sets the address window for the display.
+    async fn set_address_window(
+        &mut self,
+        sx: u16,
+        sy: u16,
+        ex: u16,
+        ey: u16,
+    ) -> Result<(), Error> {
+        // add clipping offsets if present
+        let offset = self.options.window_offset();
+        let (sx, sy, ex, ey) = (sx + offset.0, sy + offset.1, ex + offset.0, ey + offset.1);
+
+        self.dcs
+            .write_command(dcs::SetColumnAddress::new(sx, ex))
+            .await?;
+        self.dcs
+            .write_command(dcs::SetPageAddress::new(sy, ey))
+            .await
+    }
+
+    ///
+    /// Configures the tearing effect output.
+    ///
+    pub async fn set_tearing_effect(&mut self, tearing_effect: TearingEffect) -> Result<(), Error> {
+        self.dcs
+            .write_command(dcs::SetTearingEffect(tearing_effect))
+            .await
+    }
+}

--- a/mipidsi-async/src/lib.rs
+++ b/mipidsi-async/src/lib.rs
@@ -94,8 +94,8 @@ use models::Model;
 
 // mod graphics;
 
-// #[cfg(feature = "batch")]
-// mod batch;
+#[cfg(feature = "batch")]
+mod batch;
 
 ///
 /// Display driver to connect to TFT displays.

--- a/mipidsi-async/src/models.rs
+++ b/mipidsi-async/src/models.rs
@@ -1,0 +1,75 @@
+//! Display models.
+
+use crate::dcs::Dcs;
+use display_interface::AsyncWriteOnlyDataCommand;
+use embedded_graphics_core::prelude::RgbColor;
+use embedded_hal::digital::OutputPin;
+use embedded_hal_async::delay::DelayUs;
+use mipidsi::{dcs::SetAddressMode, error::InitError, Error, ModelOptions};
+
+// existing model implementations
+// mod gc9a01;
+// mod ili9341;
+// mod ili9342c;
+// mod ili934x;
+// mod ili9486;
+// mod st7735s;
+// mod st7789;
+
+// pub use gc9a01::*;
+// pub use ili9341::*;
+// pub use ili9342c::*;
+// pub use ili9486::*;
+// pub use st7735s::*;
+// pub use st7789::*;
+
+/// Display model.
+pub trait Model {
+    /// The color format.
+    type ColorFormat: RgbColor;
+
+    /// Initializes the display for this model with MADCTL from [crate::Display]
+    /// and returns the value of MADCTL set by init
+    async fn init<RST, DELAY, DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+        rst: &mut Option<RST>,
+    ) -> Result<SetAddressMode, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs,
+        DI: AsyncWriteOnlyDataCommand;
+
+    /// Resets the display using a reset pin.
+    async fn hard_reset<RST, DELAY>(
+        &mut self,
+        rst: &mut RST,
+        delay: &mut DELAY,
+    ) -> Result<(), InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs,
+    {
+        rst.set_low().map_err(InitError::Pin)?;
+        delay.delay_us(10);
+        rst.set_high().map_err(InitError::Pin)?;
+
+        Ok(())
+    }
+
+    /// Writes pixels to the display IC via the given display interface.
+    ///
+    /// Any pixel color format conversion is done here.
+    async fn write_pixels<DI, I>(&mut self, di: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+    where
+        DI: AsyncWriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>;
+
+    /// Creates default [ModelOptions] for this particular [Model].
+    ///
+    /// This serves as a "sane default". There can be additional variants which will be provided via
+    /// helper constructors.
+    fn default_options() -> ModelOptions;
+}

--- a/mipidsi-async/src/models.rs
+++ b/mipidsi-async/src/models.rs
@@ -8,18 +8,18 @@ use embedded_hal_async::delay::DelayUs;
 use mipidsi::{dcs::SetAddressMode, error::InitError, Error, ModelOptions};
 
 // existing model implementations
-// mod gc9a01;
-// mod ili9341;
-// mod ili9342c;
-// mod ili934x;
-// mod ili9486;
+mod gc9a01;
+mod ili9341;
+mod ili9342c;
+mod ili934x;
+mod ili9486;
 // mod st7735s;
 // mod st7789;
 
-// pub use gc9a01::*;
-// pub use ili9341::*;
-// pub use ili9342c::*;
-// pub use ili9486::*;
+pub use gc9a01::*;
+pub use ili9341::*;
+pub use ili9342c::*;
+pub use ili9486::*;
 // pub use st7735s::*;
 // pub use st7789::*;
 

--- a/mipidsi-async/src/models.rs
+++ b/mipidsi-async/src/models.rs
@@ -13,15 +13,15 @@ mod ili9341;
 mod ili9342c;
 mod ili934x;
 mod ili9486;
-// mod st7735s;
-// mod st7789;
+mod st7735s;
+mod st7789;
 
 pub use gc9a01::*;
 pub use ili9341::*;
 pub use ili9342c::*;
 pub use ili9486::*;
-// pub use st7735s::*;
-// pub use st7789::*;
+pub use st7735s::*;
+pub use st7789::*;
 
 /// Display model.
 pub trait Model {

--- a/mipidsi-async/src/models/gc9a01.rs
+++ b/mipidsi-async/src/models/gc9a01.rs
@@ -1,0 +1,180 @@
+use display_interface::{AsyncWriteOnlyDataCommand, DataFormat};
+use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
+use embedded_hal::digital::OutputPin;
+use embedded_hal_async::delay::DelayUs;
+use mipidsi::error::InitError;
+
+use crate::{
+    dcs::{
+        BitsPerPixel, ExitSleepMode, PixelFormat, SetAddressMode, SetDisplayOn, SetInvertMode,
+        SetPixelFormat, SoftReset, WriteMemoryStart,
+    },
+    Builder, Error, ModelOptions,
+};
+
+use super::{Dcs, Model};
+
+/// GC9A01 display in Rgb565 color mode.
+pub struct GC9A01;
+
+impl Model for GC9A01 {
+    type ColorFormat = Rgb565;
+
+    async fn init<RST, DELAY, DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+        rst: &mut Option<RST>,
+    ) -> Result<SetAddressMode, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs,
+        DI: AsyncWriteOnlyDataCommand,
+    {
+        let madctl = SetAddressMode::from(options);
+
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay).await?,
+            None => dcs.write_command(SoftReset).await?,
+        }
+        delay.delay_us(200_000).await;
+
+        dcs.write_raw(0xEF, &[]).await?; // inter register enable 2
+        dcs.write_raw(0xEB, &[0x14]).await?;
+        dcs.write_raw(0xFE, &[]).await?; // inter register enable 1
+        dcs.write_raw(0xEF, &[]).await?; // inter register enable 2
+        dcs.write_raw(0xEB, &[0x14]).await?;
+
+        dcs.write_raw(0x84, &[0x40]).await?;
+        dcs.write_raw(0x85, &[0xFF]).await?;
+        dcs.write_raw(0x86, &[0xFF]).await?;
+        dcs.write_raw(0x87, &[0xFF]).await?;
+        dcs.write_raw(0x88, &[0x0A]).await?;
+        dcs.write_raw(0x89, &[0x21]).await?;
+        dcs.write_raw(0x8A, &[0x00]).await?;
+        dcs.write_raw(0x8B, &[0x80]).await?;
+        dcs.write_raw(0x8C, &[0x01]).await?;
+        dcs.write_raw(0x8D, &[0x01]).await?;
+        dcs.write_raw(0x8E, &[0xFF]).await?;
+        dcs.write_raw(0x8F, &[0xFF]).await?;
+
+        dcs.write_raw(0xB6, &[0x00, 0x20]).await?; // display function control
+
+        dcs.write_command(madctl).await?; // set memory data access control, Top -> Bottom, RGB, Left -> Right
+
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+        dcs.write_command(SetPixelFormat::new(pf)).await?; // set interface pixel format, 16bit pixel into frame memory
+
+        dcs.write_raw(0x90, &[0x08, 0x08, 0x08, 0x08]).await?;
+        dcs.write_raw(0xBD, &[0x06]).await?;
+        dcs.write_raw(0xBC, &[0x00]).await?;
+        dcs.write_raw(0xFF, &[0x60, 0x01, 0x04]).await?;
+
+        dcs.write_raw(0xC3, &[0x13]).await?; // power control 2
+        dcs.write_raw(0xC4, &[0x13]).await?; // power control 3
+        dcs.write_raw(0xC9, &[0x22]).await?; // power control 4
+
+        dcs.write_raw(0xBE, &[0x11]).await?;
+        dcs.write_raw(0xE1, &[0x10, 0x0E]).await?;
+        dcs.write_raw(0xDF, &[0x20, 0x0c, 0x02]).await?;
+
+        dcs.write_raw(0xF0, &[0x45, 0x09, 0x08, 0x08, 0x26, 0x2A])
+            .await?; // gamma 1
+        dcs.write_raw(0xF1, &[0x43, 0x70, 0x72, 0x36, 0x37, 0x6f])
+            .await?; // gamma 2
+        dcs.write_raw(0xF2, &[0x45, 0x09, 0x08, 0x08, 0x26, 0x2A])
+            .await?; // gamma 3
+        dcs.write_raw(0xF3, &[0x43, 0x70, 0x72, 0x36, 0x37, 0x6f])
+            .await?; // gamma 4
+
+        dcs.write_raw(0xED, &[0x18, 0x0B]).await?;
+        dcs.write_raw(0xAE, &[0x77]).await?;
+        dcs.write_raw(0xCD, &[0x63]).await?;
+
+        dcs.write_raw(
+            0x70,
+            &[0x07, 0x07, 0x04, 0x0E, 0x0F, 0x09, 0x07, 0x08, 0x03],
+        )
+        .await?;
+
+        dcs.write_raw(0xE8, &[0x34]).await?; // framerate
+
+        dcs.write_raw(
+            0x62,
+            &[
+                0x18, 0x0D, 0x71, 0xED, 0x70, 0x70, 0x18, 0x0F, 0x71, 0xEF, 0x70, 0x70,
+            ],
+        )
+        .await?;
+        dcs.write_raw(
+            0x63,
+            &[
+                0x18, 0x11, 0x71, 0xF1, 0x70, 0x70, 0x18, 0x13, 0x71, 0xF3, 0x70, 0x70,
+            ],
+        )
+        .await?;
+        dcs.write_raw(0x64, &[0x28, 0x29, 0xF1, 0x01, 0xF1, 0x00, 0x07])
+            .await?;
+        dcs.write_raw(
+            0x66,
+            &[0x3C, 0x00, 0xCD, 0x67, 0x45, 0x45, 0x10, 0x00, 0x00, 0x00],
+        )
+        .await?;
+        dcs.write_raw(
+            0x67,
+            &[0x00, 0x3C, 0x00, 0x00, 0x00, 0x01, 0x54, 0x10, 0x32, 0x98],
+        )
+        .await?;
+
+        dcs.write_raw(0x74, &[0x10, 0x85, 0x80, 0x00, 0x00, 0x4E, 0x00])
+            .await?;
+        dcs.write_raw(0x98, &[0x3e, 0x07]).await?;
+
+        dcs.write_command(SetInvertMode(options.invert_colors))
+            .await?; // set color inversion
+
+        dcs.write_command(ExitSleepMode).await?; // turn off sleep
+        delay.delay_us(120_000);
+
+        dcs.write_command(SetDisplayOn).await?; // turn on display
+
+        Ok(madctl)
+    }
+
+    async fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+    where
+        DI: AsyncWriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        dcs.write_command(WriteMemoryStart).await?;
+        let mut iter = colors.into_iter().map(|c| c.into_storage());
+
+        let buf = DataFormat::U16BEIter(&mut iter);
+        dcs.di.send_data(buf).await?;
+        Ok(())
+    }
+
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((240, 240), (240, 240))
+    }
+}
+
+// simplified constructor on Display
+
+impl<DI> Builder<DI, GC9A01>
+where
+    DI: AsyncWriteOnlyDataCommand,
+{
+    /// Creates a new display builder for GC9A01 displays in Rgb565 color mode.
+    ///
+    /// The default framebuffer size is 240x240 pixels and display size is 240x240 pixels.
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [display interface](AsyncWriteOnlyDataCommand) for communicating with the display
+    ///
+    pub fn gc9a01(di: DI) -> Self {
+        Self::with_model(di, GC9A01)
+    }
+}

--- a/mipidsi-async/src/models/ili9341.rs
+++ b/mipidsi-async/src/models/ili9341.rs
@@ -1,0 +1,135 @@
+use display_interface::AsyncWriteOnlyDataCommand;
+use embedded_graphics_core::pixelcolor::{Rgb565, Rgb666};
+use embedded_hal::digital::OutputPin;
+use embedded_hal_async::delay::DelayUs;
+use mipidsi::error::InitError;
+
+use crate::{
+    dcs::{BitsPerPixel, Dcs, PixelFormat, SetAddressMode, SoftReset},
+    models::{ili934x, Model},
+    Builder, Error, ModelOptions,
+};
+
+/// ILI9341 display in Rgb565 color mode.
+pub struct ILI9341Rgb565;
+
+/// ILI9341 display in Rgb666 color mode.
+pub struct ILI9341Rgb666;
+
+impl Model for ILI9341Rgb565 {
+    type ColorFormat = Rgb565;
+
+    async fn init<RST, DELAY, DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+        rst: &mut Option<RST>,
+    ) -> Result<SetAddressMode, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs,
+        DI: AsyncWriteOnlyDataCommand,
+    {
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay).await?,
+            None => dcs.write_command(SoftReset).await?,
+        }
+
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+        ili934x::init_common(dcs, delay, options, pf)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+    where
+        DI: AsyncWriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        ili934x::write_pixels_rgb565(dcs, colors).await
+    }
+
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((240, 320), (240, 320))
+    }
+}
+
+impl Model for ILI9341Rgb666 {
+    type ColorFormat = Rgb666;
+
+    async fn init<RST, DELAY, DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+        rst: &mut Option<RST>,
+    ) -> Result<SetAddressMode, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs,
+        DI: AsyncWriteOnlyDataCommand,
+    {
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay).await?,
+            None => dcs.write_command(SoftReset).await?,
+        }
+
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+        ili934x::init_common(dcs, delay, options, pf)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+    where
+        DI: AsyncWriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        ili934x::write_pixels_rgb666(dcs, colors).await
+    }
+
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((240, 320), (240, 320))
+    }
+}
+
+// simplified constructor for Display
+
+impl<DI> Builder<DI, ILI9341Rgb565>
+where
+    DI: AsyncWriteOnlyDataCommand,
+{
+    /// Creates a new display builder for an ILI9341 display in Rgb565 color mode.
+    ///
+    /// The default framebuffer size and display size is 240x320 pixels.
+    ///
+    /// # Limitations
+    ///
+    /// The Rgb565 color mode is not supported for displays with SPI connection.
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [display interface](AsyncWriteOnlyDataCommand) for communicating with the display
+    ///
+    pub fn ili9341_rgb565(di: DI) -> Self {
+        Self::with_model(di, ILI9341Rgb565)
+    }
+}
+
+impl<DI> Builder<DI, ILI9341Rgb666>
+where
+    DI: AsyncWriteOnlyDataCommand,
+{
+    /// Creates a new display builder for an ILI9341 display in Rgb565 color mode.
+    ///
+    /// The default framebuffer size and display size is 240x320 pixels.
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [display interface](AsyncWriteOnlyDataCommand) for communicating with the display
+    ///
+    pub fn ili9341_rgb666(di: DI) -> Self {
+        Self::with_model(di, ILI9341Rgb666)
+    }
+}

--- a/mipidsi-async/src/models/ili9342c.rs
+++ b/mipidsi-async/src/models/ili9342c.rs
@@ -1,0 +1,135 @@
+use display_interface::AsyncWriteOnlyDataCommand;
+use embedded_graphics_core::pixelcolor::{Rgb565, Rgb666};
+use embedded_hal::digital::OutputPin;
+use embedded_hal_async::delay::DelayUs;
+use mipidsi::error::InitError;
+
+use crate::{
+    dcs::{BitsPerPixel, Dcs, PixelFormat, SetAddressMode, SoftReset},
+    models::{ili934x, Model},
+    Builder, Error, ModelOptions,
+};
+
+/// ILI9342C display in Rgb565 color mode.
+pub struct ILI9342CRgb565;
+
+/// ILI9342C display in Rgb666 color mode.
+pub struct ILI9342CRgb666;
+
+impl Model for ILI9342CRgb565 {
+    type ColorFormat = Rgb565;
+
+    async fn init<RST, DELAY, DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+        rst: &mut Option<RST>,
+    ) -> Result<SetAddressMode, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs,
+        DI: AsyncWriteOnlyDataCommand,
+    {
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay).await?,
+            None => dcs.write_command(SoftReset).await?,
+        }
+
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+        ili934x::init_common(dcs, delay, options, pf)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+    where
+        DI: AsyncWriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        ili934x::write_pixels_rgb565(dcs, colors).await
+    }
+
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((320, 240), (320, 240))
+    }
+}
+
+impl Model for ILI9342CRgb666 {
+    type ColorFormat = Rgb666;
+
+    async fn init<RST, DELAY, DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+        rst: &mut Option<RST>,
+    ) -> Result<SetAddressMode, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs,
+        DI: AsyncWriteOnlyDataCommand,
+    {
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay).await?,
+            None => dcs.write_command(SoftReset).await?,
+        }
+
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+        ili934x::init_common(dcs, delay, options, pf)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+    where
+        DI: AsyncWriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        ili934x::write_pixels_rgb666(dcs, colors).await
+    }
+
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((320, 240), (320, 240))
+    }
+}
+
+// simplified constructor for Display
+
+impl<DI> Builder<DI, ILI9342CRgb565>
+where
+    DI: AsyncWriteOnlyDataCommand,
+{
+    /// Creates a new display builder for an ILI9342C display in Rgb565 color mode.
+    ///
+    /// The default framebuffer size and display size is 320x240 pixels.
+    ///
+    /// # Limitations
+    ///
+    /// The Rgb565 color mode is not supported for displays with SPI connection.
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [display interface](AsyncWriteOnlyDataCommand) for communicating with the display
+    ///
+    pub fn ili9342c_rgb565(di: DI) -> Self {
+        Self::with_model(di, ILI9342CRgb565)
+    }
+}
+
+impl<DI> Builder<DI, ILI9342CRgb666>
+where
+    DI: AsyncWriteOnlyDataCommand,
+{
+    /// Creates a new display builder for an ILI9342C display in Rgb666 color mode.
+    ///
+    /// The default framebuffer size and display size is 320x240
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [display interface](AsyncWriteOnlyDataCommand) for communicating with the display
+    ///
+    pub fn ili9342c_rgb666(di: DI) -> Self {
+        Self::with_model(di, ILI9342CRgb666)
+    }
+}

--- a/mipidsi-async/src/models/ili934x.rs
+++ b/mipidsi-async/src/models/ili934x.rs
@@ -1,0 +1,84 @@
+use display_interface::{AsyncWriteOnlyDataCommand, DataFormat};
+use embedded_graphics_core::pixelcolor::{IntoStorage, Rgb565, Rgb666, RgbColor};
+use embedded_hal_async::delay::DelayUs;
+use mipidsi::dcs::EnterNormalMode;
+
+use crate::{
+    dcs::{
+        ExitSleepMode, PixelFormat, SetAddressMode, SetDisplayOn, SetInvertMode, SetPixelFormat,
+        WriteMemoryStart,
+    },
+    Error, ModelOptions,
+};
+
+use super::Dcs;
+
+/// Common init for all ILI934x controllers and color formats.
+pub async fn init_common<DELAY, DI>(
+    dcs: &mut Dcs<DI>,
+    delay: &mut DELAY,
+    options: &ModelOptions,
+    pixel_format: PixelFormat,
+) -> Result<SetAddressMode, Error>
+where
+    DELAY: DelayUs,
+    DI: AsyncWriteOnlyDataCommand,
+{
+    let madctl = SetAddressMode::from(options);
+
+    // 15.4:  It is necessary to wait 5msec after releasing RESX before sending commands.
+    // 8.2.2: It will be necessary to wait 5msec before sending new command following software reset.
+    delay.delay_us(5_000).await;
+
+    dcs.write_command(madctl).await?;
+    dcs.write_raw(0xB4, &[0x0]).await?;
+    dcs.write_command(SetInvertMode(options.invert_colors))
+        .await?;
+    dcs.write_command(SetPixelFormat::new(pixel_format)).await?;
+
+    dcs.write_command(EnterNormalMode).await?;
+
+    // 8.2.12: It will be necessary to wait 120msec after sending Sleep In command (when in Sleep Out mode)
+    //          before Sleep Out command can be sent.
+    // The reset might have implicitly called the Sleep In command if the controller is reinitialized.
+    delay.delay_us(120_000);
+
+    dcs.write_command(ExitSleepMode).await?;
+
+    // 8.2.12: It takes 120msec to become Sleep Out mode after SLPOUT command issued.
+    // 13.2 Power ON Sequence: Delay should be 60ms + 80ms
+    delay.delay_us(140_000);
+
+    dcs.write_command(SetDisplayOn).await?;
+
+    Ok(madctl)
+}
+
+pub async fn write_pixels_rgb565<DI, I>(dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+where
+    DI: AsyncWriteOnlyDataCommand,
+    I: IntoIterator<Item = Rgb565>,
+{
+    dcs.write_command(WriteMemoryStart).await?;
+    let mut iter = colors.into_iter().map(|c| c.into_storage());
+
+    let buf = DataFormat::U16BEIter(&mut iter);
+    dcs.di.send_data(buf).await
+}
+
+pub async fn write_pixels_rgb666<DI, I>(dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+where
+    DI: AsyncWriteOnlyDataCommand,
+    I: IntoIterator<Item = Rgb666>,
+{
+    dcs.write_command(WriteMemoryStart).await?;
+    let mut iter = colors.into_iter().flat_map(|c| {
+        let red = c.r() << 2;
+        let green = c.g() << 2;
+        let blue = c.b() << 2;
+        [red, green, blue]
+    });
+
+    let buf = DataFormat::U8Iter(&mut iter);
+    dcs.di.send_data(buf).await
+}

--- a/mipidsi-async/src/models/ili9468.rs
+++ b/mipidsi-async/src/models/ili9468.rs
@@ -1,0 +1,185 @@
+use crate::{
+    dcs::{
+        BitsPerPixel, Dcs, EnterNormalMode, ExitSleepMode, PixelFormat, SetAddressMode,
+        SetDisplayOn, SetInvertMode, SetPixelFormat, SoftReset, WriteMemoryStart,
+    },
+    error::InitError,
+    Builder, Error, ModelOptions,
+};
+use display_interface::AsyncWriteOnlyDataCommand;
+use embedded_graphics_core::pixelcolor::{Rgb565, Rgb666};
+use embedded_hal::digital::OutputPin;
+use embedded_hal_async::delay::DelayUs;
+use mipidsi::error::InitError;
+
+use super::Model;
+
+/// ILI9486 display in Rgb565 color mode.
+pub struct ILI9486Rgb565;
+
+/// ILI9486 display in Rgb666 color mode.
+pub struct ILI9486Rgb666;
+
+impl Model for ILI9486Rgb565 {
+    type ColorFormat = Rgb565;
+
+    async fn init<RST, DELAY, DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+        rst: &mut Option<RST>,
+    ) -> Result<SetAddressMode, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs<u32>,
+        DI: AsyncWriteOnlyDataCommand,
+    {
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay).await?,
+            None => dcs.write_command(SoftReset).await?,
+        }
+        delay.delay_us(120_000).await;
+
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+        Ok(init_common(dcs, delay, options, pf).await?)
+    }
+
+    async fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+    where
+        DI: AsyncWriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        dcs.write_command(WriteMemoryStart).await?;
+        let mut iter = colors.into_iter().map(|c| c.into_storage());
+
+        let buf = DataFormat::U16BEIter(&mut iter);
+        dcs.di.send_data(buf).await
+    }
+
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((320, 480), (320, 480))
+    }
+}
+
+impl Model for ILI9486Rgb666 {
+    type ColorFormat = Rgb666;
+
+    async fn init<RST, DELAY, DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+        rst: &mut Option<RST>,
+    ) -> Result<SetAddressMode, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs<u32>,
+        DI: AsyncWriteOnlyDataCommand,
+    {
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay).await?,
+            None => dcs.write_command(SoftReset).await?,
+        };
+
+        delay.delay_us(120_000).await;
+
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+        Ok(init_common(dcs, delay, options, pf).await?)
+    }
+
+    async fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+    where
+        DI: AsyncWriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        dcs.write_command(WriteMemoryStart).await?;
+        let mut iter = colors.into_iter().flat_map(|c| {
+            let red = c.r() << 2;
+            let green = c.g() << 2;
+            let blue = c.b() << 2;
+            [red, green, blue]
+        });
+
+        let buf = DataFormat::U8Iter(&mut iter);
+        dcs.di.send_data(buf).await
+    }
+
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((320, 480), (320, 480))
+    }
+}
+
+// simplified constructor for Display
+
+impl<DI> Builder<DI, ILI9486Rgb565>
+where
+    DI: AsyncWriteOnlyDataCommand,
+{
+    /// Creates a new display builder for an ILI9486 display in Rgb565 color mode.
+    ///
+    /// The default framebuffer size and display size is 320x480 pixels.
+    ///
+    /// # Limitations
+    ///
+    /// The Rgb565 color mode is not supported for displays with SPI connection.
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [display interface](AsyncWriteOnlyDataCommand) for communicating with the display
+    ///
+    pub fn ili9486_rgb565(di: DI) -> Self {
+        Self::with_model(di, ILI9486Rgb565)
+    }
+}
+
+impl<DI> Builder<DI, ILI9486Rgb666>
+where
+    DI: AsyncWriteOnlyDataCommand,
+{
+    /// Creates a new display builder for ILI9486 displays in Rgb666 color mode.
+    ///
+    /// The default framebuffer size and display size is 320x480 pixels.
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [display interface](AsyncWriteOnlyDataCommand) for communicating with the display
+    ///
+    pub fn ili9486_rgb666(di: DI) -> Self {
+        Self::with_model(di, ILI9486Rgb666)
+    }
+}
+
+// common init for all color format models
+fn init_common<DELAY, DI>(
+    dcs: &mut Dcs<DI>,
+    delay: &mut DELAY,
+    options: &ModelOptions,
+    pixel_format: PixelFormat,
+) -> Result<SetAddressMode, Error>
+where
+    DELAY: DelayUs<u32>,
+    DI: AsyncWriteOnlyDataCommand,
+{
+    let madctl = SetAddressMode::from(options);
+    dcs.write_command(ExitSleepMode).await?; // turn off sleep
+    dcs.write_command(SetPixelFormat::new(pixel_format)).await?; // pixel format
+    dcs.write_command(madctl).await?; // left -> right, bottom -> top RGB
+                                      // dcs.write_command(Instruction::VCMOFSET, &[0x00, 0x48, 0x00, 0x48]).await?; //VCOM  Control 1 [00 40 00 40]
+                                      // dcs.write_command(Instruction::INVCO, &[0x0]).await?; //Inversion Control [00]
+    dcs.write_command(SetInvertMode(options.invert_colors))
+        .await?;
+
+    // optional gamma setup
+    // dcs.write_raw(Instruction::PGC, &[0x00, 0x2C, 0x2C, 0x0B, 0x0C, 0x04, 0x4C, 0x64, 0x36, 0x03, 0x0E, 0x01, 0x10, 0x01, 0x00]).await?; // Positive Gamma Control
+    // dcs.write_raw(Instruction::NGC, &[0x0F, 0x37, 0x37, 0x0C, 0x0F, 0x05, 0x50, 0x32, 0x36, 0x04, 0x0B, 0x00, 0x19, 0x14, 0x0F]).await?; // Negative Gamma Control
+
+    dcs.write_raw(0xB6, &[0b0000_0010, 0x02, 0x3B]).await?; // DFC
+    dcs.write_command(EnterNormalMode).await?; // turn to normal mode
+    dcs.write_command(SetDisplayOn).await?; // turn on display
+
+    // DISPON requires some time otherwise we risk SPI data issues
+    delay.delay_us(120_000).await;
+
+    Ok(madctl)
+}

--- a/mipidsi-async/src/models/ili9486.rs
+++ b/mipidsi-async/src/models/ili9486.rs
@@ -1,0 +1,185 @@
+use crate::{
+    dcs::{
+        BitsPerPixel, Dcs, EnterNormalMode, ExitSleepMode, PixelFormat, SetAddressMode,
+        SetDisplayOn, SetInvertMode, SetPixelFormat, SoftReset, WriteMemoryStart,
+    },
+    Builder, Error, ModelOptions,
+};
+use display_interface::{AsyncWriteOnlyDataCommand, DataFormat};
+use embedded_graphics_core::pixelcolor::{Rgb565, Rgb666};
+use embedded_graphics_core::{pixelcolor::RgbColor, prelude::IntoStorage};
+use embedded_hal::digital::OutputPin;
+use embedded_hal_async::delay::DelayUs;
+use mipidsi::error::InitError;
+
+use super::Model;
+
+/// ILI9486 display in Rgb565 color mode.
+pub struct ILI9486Rgb565;
+
+/// ILI9486 display in Rgb666 color mode.
+pub struct ILI9486Rgb666;
+
+impl Model for ILI9486Rgb565 {
+    type ColorFormat = Rgb565;
+
+    async fn init<RST, DELAY, DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+        rst: &mut Option<RST>,
+    ) -> Result<SetAddressMode, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs,
+        DI: AsyncWriteOnlyDataCommand,
+    {
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay).await?,
+            None => dcs.write_command(SoftReset).await?,
+        }
+        delay.delay_us(120_000).await;
+
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+        Ok(init_common(dcs, delay, options, pf).await?)
+    }
+
+    async fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+    where
+        DI: AsyncWriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        dcs.write_command(WriteMemoryStart).await?;
+        let mut iter = colors.into_iter().map(|c| c.into_storage());
+
+        let buf = DataFormat::U16BEIter(&mut iter);
+        dcs.di.send_data(buf).await
+    }
+
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((320, 480), (320, 480))
+    }
+}
+
+impl Model for ILI9486Rgb666 {
+    type ColorFormat = Rgb666;
+
+    async fn init<RST, DELAY, DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+        rst: &mut Option<RST>,
+    ) -> Result<SetAddressMode, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs,
+        DI: AsyncWriteOnlyDataCommand,
+    {
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay).await?,
+            None => dcs.write_command(SoftReset).await?,
+        };
+
+        delay.delay_us(120_000).await;
+
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+        Ok(init_common(dcs, delay, options, pf).await?)
+    }
+
+    async fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+    where
+        DI: AsyncWriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        dcs.write_command(WriteMemoryStart).await?;
+        let mut iter = colors.into_iter().flat_map(|c| {
+            let red = c.r() << 2;
+            let green = c.g() << 2;
+            let blue = c.b() << 2;
+            [red, green, blue]
+        });
+
+        let buf = DataFormat::U8Iter(&mut iter);
+        dcs.di.send_data(buf).await
+    }
+
+    fn default_options() -> ModelOptions {
+        ModelOptions::with_sizes((320, 480), (320, 480))
+    }
+}
+
+// simplified constructor for Display
+
+impl<DI> Builder<DI, ILI9486Rgb565>
+where
+    DI: AsyncWriteOnlyDataCommand,
+{
+    /// Creates a new display builder for an ILI9486 display in Rgb565 color mode.
+    ///
+    /// The default framebuffer size and display size is 320x480 pixels.
+    ///
+    /// # Limitations
+    ///
+    /// The Rgb565 color mode is not supported for displays with SPI connection.
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [display interface](AsyncWriteOnlyDataCommand) for communicating with the display
+    ///
+    pub fn ili9486_rgb565(di: DI) -> Self {
+        Self::with_model(di, ILI9486Rgb565)
+    }
+}
+
+impl<DI> Builder<DI, ILI9486Rgb666>
+where
+    DI: AsyncWriteOnlyDataCommand,
+{
+    /// Creates a new display builder for ILI9486 displays in Rgb666 color mode.
+    ///
+    /// The default framebuffer size and display size is 320x480 pixels.
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [display interface](AsyncWriteOnlyDataCommand) for communicating with the display
+    ///
+    pub fn ili9486_rgb666(di: DI) -> Self {
+        Self::with_model(di, ILI9486Rgb666)
+    }
+}
+
+// common init for all color format models
+async fn init_common<DELAY, DI>(
+    dcs: &mut Dcs<DI>,
+    delay: &mut DELAY,
+    options: &ModelOptions,
+    pixel_format: PixelFormat,
+) -> Result<SetAddressMode, Error>
+where
+    DELAY: DelayUs,
+    DI: AsyncWriteOnlyDataCommand,
+{
+    let madctl = SetAddressMode::from(options);
+    dcs.write_command(ExitSleepMode).await?; // turn off sleep
+    dcs.write_command(SetPixelFormat::new(pixel_format)).await?; // pixel format
+    dcs.write_command(madctl).await?; // left -> right, bottom -> top RGB
+                                      // dcs.write_command(Instruction::VCMOFSET, &[0x00, 0x48, 0x00, 0x48]).await?; //VCOM  Control 1 [00 40 00 40]
+                                      // dcs.write_command(Instruction::INVCO, &[0x0]).await?; //Inversion Control [00]
+    dcs.write_command(SetInvertMode(options.invert_colors))
+        .await?;
+
+    // optional gamma setup
+    // dcs.write_raw(Instruction::PGC, &[0x00, 0x2C, 0x2C, 0x0B, 0x0C, 0x04, 0x4C, 0x64, 0x36, 0x03, 0x0E, 0x01, 0x10, 0x01, 0x00]).await?; // Positive Gamma Control
+    // dcs.write_raw(Instruction::NGC, &[0x0F, 0x37, 0x37, 0x0C, 0x0F, 0x05, 0x50, 0x32, 0x36, 0x04, 0x0B, 0x00, 0x19, 0x14, 0x0F]).await?; // Negative Gamma Control
+
+    dcs.write_raw(0xB6, &[0b0000_0010, 0x02, 0x3B]).await?; // DFC
+    dcs.write_command(EnterNormalMode).await?; // turn to normal mode
+    dcs.write_command(SetDisplayOn).await?; // turn on display
+
+    // DISPON requires some time otherwise we risk SPI data issues
+    delay.delay_us(120_000);
+
+    Ok(madctl)
+}

--- a/mipidsi-async/src/models/st7735s.rs
+++ b/mipidsi-async/src/models/st7735s.rs
@@ -1,0 +1,123 @@
+use crate::{
+    dcs::{
+        BitsPerPixel, Dcs, ExitSleepMode, PixelFormat, SetAddressMode, SetDisplayOn, SetInvertMode,
+        SetPixelFormat, SoftReset, WriteMemoryStart,
+    },
+    Builder, Error, ModelOptions,
+};
+use display_interface::{AsyncWriteOnlyDataCommand, DataFormat};
+use embedded_graphics_core::pixelcolor::Rgb565;
+use embedded_graphics_core::prelude::IntoStorage;
+use embedded_hal::digital::OutputPin;
+use embedded_hal_async::delay::DelayUs;
+use mipidsi::{error::InitError, ColorInversion};
+
+use super::Model;
+
+/// ST7735s display in Rgb565 color mode.
+pub struct ST7735s;
+
+impl Model for ST7735s {
+    type ColorFormat = Rgb565;
+
+    async fn init<RST, DELAY, DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+        rst: &mut Option<RST>,
+    ) -> Result<SetAddressMode, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs,
+        DI: AsyncWriteOnlyDataCommand,
+    {
+        let madctl = SetAddressMode::from(options);
+
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay).await?,
+            None => dcs.write_command(SoftReset).await?,
+        }
+        delay.delay_us(200_000).await;
+
+        dcs.write_command(ExitSleepMode).await?; // turn off sleep
+        delay.delay_us(120_000).await;
+
+        dcs.write_command(SetInvertMode(options.invert_colors))
+            .await?; // set color inversion
+        dcs.write_raw(0xB1, &[0x05, 0x3A, 0x3A]).await?; // set frame rate
+        dcs.write_raw(0xB2, &[0x05, 0x3A, 0x3A]).await?; // set frame rate
+        dcs.write_raw(0xB3, &[0x05, 0x3A, 0x3A, 0x05, 0x3A, 0x3A])
+            .await?; // set frame rate
+        dcs.write_raw(0xB4, &[0b0000_0011]).await?; // set inversion control
+        dcs.write_raw(0xC0, &[0x62, 0x02, 0x04]).await?; // set power control 1
+        dcs.write_raw(0xC1, &[0xC0]).await?; // set power control 2
+        dcs.write_raw(0xC2, &[0x0D, 0x00]).await?; // set power control 3
+        dcs.write_raw(0xC3, &[0x8D, 0x6A]).await?; // set power control 4
+        dcs.write_raw(0xC4, &[0x8D, 0xEE]).await?; // set power control 5
+        dcs.write_raw(0xC5, &[0x0E]).await?; // set VCOM control 1
+        dcs.write_raw(
+            0xE0,
+            &[
+                0x10, 0x0E, 0x02, 0x03, 0x0E, 0x07, 0x02, 0x07, 0x0A, 0x12, 0x27, 0x37, 0x00, 0x0D,
+                0x0E, 0x10,
+            ],
+        )
+        .await?; // set GAMMA +Polarity characteristics
+        dcs.write_raw(
+            0xE1,
+            &[
+                0x10, 0x0E, 0x03, 0x03, 0x0F, 0x06, 0x02, 0x08, 0x0A, 0x13, 0x26, 0x36, 0x00, 0x0D,
+                0x0E, 0x10,
+            ],
+        )
+        .await?; // set GAMMA -Polarity characteristics
+
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+        dcs.write_command(SetPixelFormat::new(pf)).await?; // set interface pixel format, 16bit pixel into frame memory
+
+        dcs.write_command(madctl).await?; // set memory data access control, Top -> Bottom, RGB, Left -> Right
+        dcs.write_command(SetDisplayOn).await?; // turn on display
+
+        Ok(madctl)
+    }
+
+    async fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+    where
+        DI: AsyncWriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        dcs.write_command(WriteMemoryStart).await?;
+        let mut iter = colors.into_iter().map(|c| c.into_storage());
+
+        let buf = DataFormat::U16BEIter(&mut iter);
+        dcs.di.send_data(buf).await?;
+        Ok(())
+    }
+
+    fn default_options() -> ModelOptions {
+        let mut options = ModelOptions::with_sizes((80, 160), (132, 162));
+        options.set_invert_colors(ColorInversion::Inverted);
+
+        options
+    }
+}
+
+// simplified constructor on Display
+
+impl<DI> Builder<DI, ST7735s>
+where
+    DI: AsyncWriteOnlyDataCommand,
+{
+    /// Creates a new display builder for ST7735s displays in Rgb565 color mode.
+    ///
+    /// The default framebuffer size is 132x162 pixels and display size is 80x160 pixels.
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [display interface](WriteOnlyDataCommand) for communicating with the display
+    ///
+    pub fn st7735s(di: DI) -> Self {
+        Self::with_model(di, ST7735s)
+    }
+}

--- a/mipidsi-async/src/models/st7789.rs
+++ b/mipidsi-async/src/models/st7789.rs
@@ -1,0 +1,95 @@
+use crate::{
+    dcs::{
+        BitsPerPixel, Dcs, ExitSleepMode, PixelFormat, SetAddressMode, SetDisplayOn, SetInvertMode,
+        SetPixelFormat, SoftReset, WriteMemoryStart,
+    },
+    Error, ModelOptions,
+};
+use display_interface::{AsyncWriteOnlyDataCommand, DataFormat};
+use embedded_graphics_core::pixelcolor::Rgb565;
+use embedded_graphics_core::prelude::IntoStorage;
+use embedded_hal::digital::OutputPin;
+use embedded_hal_async::delay::DelayUs;
+use mipidsi::{
+    dcs::{EnterNormalMode, SetScrollArea},
+    error::InitError,
+    ColorInversion,
+};
+
+use super::Model;
+
+/// Module containing all ST7789 variants.
+mod variants;
+
+/// ST7789 display in Rgb565 color mode.
+///
+/// Interfaces implemented by the [display-interface](https://crates.io/crates/display-interface) are supported.
+pub struct ST7789;
+
+impl Model for ST7789 {
+    type ColorFormat = Rgb565;
+
+    async fn init<RST, DELAY, DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+        rst: &mut Option<RST>,
+    ) -> Result<SetAddressMode, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayUs,
+        DI: AsyncWriteOnlyDataCommand,
+    {
+        let madctl = SetAddressMode::from(options);
+
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay).await?,
+            None => dcs.write_command(SoftReset).await?,
+        }
+        delay.delay_us(150_000).await;
+
+        dcs.write_command(ExitSleepMode).await?;
+        delay.delay_us(10_000).await;
+
+        // set hw scroll area based on framebuffer size
+        dcs.write_command(SetScrollArea::from(options)).await?;
+        dcs.write_command(madctl).await?;
+
+        dcs.write_command(SetInvertMode(options.invert_colors))
+            .await?;
+
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+        dcs.write_command(SetPixelFormat::new(pf)).await?;
+        delay.delay_us(10_000);
+        dcs.write_command(EnterNormalMode).await?;
+        delay.delay_us(10_000);
+        dcs.write_command(SetDisplayOn).await?;
+
+        // DISPON requires some time otherwise we risk SPI data issues
+        delay.delay_us(120_000).await;
+
+        Ok(madctl)
+    }
+
+    async fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+    where
+        DI: AsyncWriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        dcs.write_command(WriteMemoryStart).await?;
+
+        let mut iter = colors.into_iter().map(Rgb565::into_storage);
+
+        let buf = DataFormat::U16BEIter(&mut iter);
+        dcs.di.send_data(buf).await?;
+        Ok(())
+    }
+
+    fn default_options() -> crate::ModelOptions {
+        let mut options = ModelOptions::with_sizes((240, 320), (240, 320));
+        options.set_invert_colors(ColorInversion::Normal);
+
+        options
+    }
+}

--- a/mipidsi-async/src/models/st7789/variants.rs
+++ b/mipidsi-async/src/models/st7789/variants.rs
@@ -1,0 +1,53 @@
+use display_interface::AsyncWriteOnlyDataCommand;
+
+use crate::{Builder, ColorInversion, ModelOptions, Orientation};
+
+use super::ST7789;
+
+impl<DI> Builder<DI, ST7789>
+where
+    DI: AsyncWriteOnlyDataCommand,
+{
+    /// Creates a new display builder for a ST7789 display in Rgb565 color mode.
+    ///
+    /// The default framebuffer size and display size is 240x320 pixels.
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [display interface](AsyncWriteOnlyDataCommand) for communicating with the display
+    ///
+    pub fn st7789(di: DI) -> Self {
+        Self::with_model(di, ST7789)
+    }
+
+    /// Creates a new display builder for the pico1 variant of a ST7789 display in Rgb565 color
+    /// mode.
+    ///
+    /// The pico1 variant uses a display and framebuffer size of 135x240 and a clipping offset.
+    ///
+    /// # Arguments
+    ///
+    /// * `di` - a [display interface](AsyncWriteOnlyDataCommand) for communicating with the display
+    ///
+    pub fn st7789_pico1(di: DI) -> Self {
+        let mut options = ModelOptions::with_all((135, 240), (135, 240), pico1_offset);
+        options.set_invert_colors(ColorInversion::Inverted);
+
+        // pico v1 is cropped to 135x240 size with an offset of (40, 53)
+        Self::new(di, ST7789, options)
+    }
+}
+
+// ST7789 pico1 variant with variable offset
+pub(crate) fn pico1_offset(options: &ModelOptions) -> (u16, u16) {
+    match options.orientation() {
+        Orientation::Portrait(false) => (52, 40),
+        Orientation::Portrait(true) => (53, 40),
+        Orientation::Landscape(false) => (40, 52),
+        Orientation::Landscape(true) => (40, 53),
+        Orientation::PortraitInverted(false) => (53, 40),
+        Orientation::PortraitInverted(true) => (52, 40),
+        Orientation::LandscapeInverted(false) => (40, 53),
+        Orientation::LandscapeInverted(true) => (40, 52),
+    }
+}

--- a/mipidsi/Cargo.toml
+++ b/mipidsi/Cargo.toml
@@ -12,9 +12,10 @@ documentation = "https://docs.rs/mipidsi"
 rust-version = "1.61"
 
 [dependencies]
-display-interface = "0.4.1"
+display-interface = { version = "0.5.0-alpha.1", git = "https://github.com/therealprof/display-interface", features = ["async"] }
 embedded-graphics-core = "0.4.0"
 embedded-hal = "0.2.7"
+
 nb = "1.0.0"
 
 [dependencies.heapless]

--- a/mipidsi/src/batch.rs
+++ b/mipidsi/src/batch.rs
@@ -140,7 +140,7 @@ where
 
 /// Batch the pixels into Pixel Rows, which are contiguous pixels on the same row.
 /// P can be any Pixel Iterator (e.g. a rectangle).
-fn to_rows<C, P>(pixels: P) -> RowIterator<C, P>
+pub fn to_rows<C, P>(pixels: P) -> RowIterator<C, P>
 where
     C: PixelColor,
     P: Iterator<Item = Pixel<C>>,
@@ -157,7 +157,7 @@ where
 
 /// Batch the Pixel Rows into Pixel Blocks, which are contiguous Pixel Rows with the same start and end column number
 /// R can be any Pixel Row Iterator.
-fn to_blocks<C, R>(rows: R) -> BlockIterator<C, R>
+pub fn to_blocks<C, R>(rows: R) -> BlockIterator<C, R>
 where
     C: PixelColor,
     R: Iterator<Item = PixelRow<C>>,

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -97,7 +97,7 @@ use models::Model;
 mod graphics;
 
 #[cfg(feature = "batch")]
-mod batch;
+pub mod batch;
 
 ///
 /// Display driver to connect to TFT displays.

--- a/mipidsi/src/options.rs
+++ b/mipidsi/src/options.rs
@@ -6,20 +6,20 @@
 #[derive(Clone)]
 pub struct ModelOptions {
     /// Specify display color ordering
-    pub(crate) color_order: ColorOrder,
+    pub color_order: ColorOrder,
     /// Initial display orientation (without inverts)
-    pub(crate) orientation: Orientation,
+    pub orientation: Orientation,
     /// Whether to invert colors for this display/model (INVON)
-    pub(crate) invert_colors: ColorInversion,
+    pub invert_colors: ColorInversion,
     /// Display refresh order
-    pub(crate) refresh_order: RefreshOrder,
+    pub refresh_order: RefreshOrder,
     /// Offset override function returning (w, h) offset for current
     /// display orientation if display is "clipped" and needs an offset for (e.g. Pico v1)
-    pub(crate) window_offset_handler: fn(&ModelOptions) -> (u16, u16),
+    pub window_offset_handler: fn(&ModelOptions) -> (u16, u16),
     /// Display size (w, h) for given display/model
-    pub(crate) display_size: (u16, u16),
+    pub display_size: (u16, u16),
     /// Framebuffer size (w, h) for given display/model
-    pub(crate) framebuffer_size: (u16, u16),
+    pub framebuffer_size: (u16, u16),
 }
 
 impl ModelOptions {
@@ -92,7 +92,7 @@ impl ModelOptions {
     /// Returns window offset (x, y) based on current orientation and display options.
     ///
     /// Used by [Display::set_address_window](crate::Display::set_address_window).
-    pub(crate) fn window_offset(&mut self) -> (u16, u16) {
+    pub fn window_offset(&mut self) -> (u16, u16) {
         (self.window_offset_handler)(self)
     }
 


### PR DESCRIPTION
Reimplemented using async as discussed in #63. Pretty much copy/paste with async/await keywords

Couples things to note:
- Async crate uses the alpha embedded-hal
- Currently using the git version of `display-interface`, we might want to wait for the release
- Some things where made public to allow reuse from the non async to async crate. 
  -  We could use a `-common` crate and put everything public and the crate but not reexport it in the main crates
- Currently the doc is copy/pasted, we might want to modify some things or just reference the base library? (e.g. "Async version of [mipidsi::Display]") Whatever you think is best for the doc