### PR TITLE
feat: Added sleep/wake methods to display

### DIFF
--- a/mipidsi/CHANGELOG.md
+++ b/mipidsi/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - added `GC9A01` model support
+- added `Display::wake` method
+- added `Display::sleep` method
 
 ## [v0.7.1] - 2023-05-24
 

--- a/mipidsi/src/builder.rs
+++ b/mipidsi/src/builder.rs
@@ -117,7 +117,8 @@ where
     ///
     /// Consumes the builder to create a new [Display] with an optional reset [OutputPin].
     /// Blocks using the provided [DelayUs] `delay_source` to perform the display initialization.
-    ///
+    /// The display will be awake ready to use, no need to call [Display::wake] after init.
+    /// 
     /// ### WARNING
     /// The reset pin needs to be in *high* state in order for the display to operate.
     /// If it wasn't provided the user needs to ensure this is the case.

--- a/mipidsi/src/builder.rs
+++ b/mipidsi/src/builder.rs
@@ -118,7 +118,7 @@ where
     /// Consumes the builder to create a new [Display] with an optional reset [OutputPin].
     /// Blocks using the provided [DelayUs] `delay_source` to perform the display initialization.
     /// The display will be awake ready to use, no need to call [Display::wake] after init.
-    /// 
+    ///
     /// ### WARNING
     /// The reset pin needs to be in *high* state in order for the display to operate.
     /// If it wasn't provided the user needs to ensure this is the case.

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -253,7 +253,7 @@ where
         self.dcs
             .write_command(dcs::SetTearingEffect(tearing_effect))
     }
-  
+
     ///
     /// Puts the display to sleep, reducing power consumption.
     /// Need to call [Self::wake] before issuing other commands
@@ -261,7 +261,7 @@ where
     pub fn sleep(&mut self) -> Result<(), Error> {
         self.dcs.write_command(dcs::EnterSleepMode)
     }
-  
+
     ///
     /// Wakes the display after it's been set to sleep via [Self::sleep]
     ///

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -80,6 +80,7 @@ use dcs::Dcs;
 use display_interface::WriteOnlyDataCommand;
 
 pub mod error;
+use embedded_hal::blocking::delay::DelayUs;
 use embedded_hal::digital::v2::OutputPin;
 pub use error::Error;
 
@@ -258,14 +259,18 @@ where
     /// Puts the display to sleep, reducing power consumption.
     /// Need to call [Self::wake] before issuing other commands
     ///
-    pub fn sleep(&mut self) -> Result<(), Error> {
-        self.dcs.write_command(dcs::EnterSleepMode)
+    pub fn sleep<D: DelayUs<u32>>(&mut self, delay: &mut D) -> Result<(), Error> {
+        self.dcs.write_command(dcs::EnterSleepMode)?;
+        delay.delay_us(120_000); // All supported models requires a 120ms delay
+        Ok(())
     }
 
     ///
     /// Wakes the display after it's been set to sleep via [Self::sleep]
     ///
-    pub fn wake(&mut self) -> Result<(), Error> {
-        self.dcs.write_command(dcs::ExitSleepMode)
+    pub fn wake<D: DelayUs<u32>>(&mut self, delay: &mut D) -> Result<(), Error> {
+        self.dcs.write_command(dcs::ExitSleepMode)?;
+        delay.delay_us(120_000); // ST77xx have the highest wait delay of 120ms
+        Ok(())
     }
 }

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -261,7 +261,8 @@ where
     ///
     pub fn sleep<D: DelayUs<u32>>(&mut self, delay: &mut D) -> Result<(), Error> {
         self.dcs.write_command(dcs::EnterSleepMode)?;
-        delay.delay_us(120_000); // All supported models requires a 120ms delay
+        // All supported models requires a 120ms delay before issuing other commands
+        delay.delay_us(120_000);
         Ok(())
     }
 
@@ -270,7 +271,8 @@ where
     ///
     pub fn wake<D: DelayUs<u32>>(&mut self, delay: &mut D) -> Result<(), Error> {
         self.dcs.write_command(dcs::ExitSleepMode)?;
-        delay.delay_us(120_000); // ST77xx have the highest wait delay of 120ms
+        // ST7789 and st7735s have the highest minimal delay of 120ms
+        delay.delay_us(120_000);
         Ok(())
     }
 }

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -253,4 +253,19 @@ where
         self.dcs
             .write_command(dcs::SetTearingEffect(tearing_effect))
     }
+  
+    ///
+    /// Puts the display to sleep, reducing power consumption.
+    /// Need to call [Self::wake] before issuing other commands
+    ///
+    pub fn sleep(&mut self) -> Result<(), Error> {
+        self.dcs.write_command(dcs::EnterSleepMode)
+    }
+  
+    ///
+    /// Wakes the display after it's been set to sleep via [Self::sleep]
+    ///
+    pub fn wake(&mut self) -> Result<(), Error> {
+        self.dcs.write_command(dcs::ExitSleepMode)
+    }
 }


### PR DESCRIPTION
I've added the `sleep` and `wake` method to the `Display` struct. Note that I have not bothered with `idle` since it only allows 8bit colors, but we can add it if you prefer. 

It saves about 20mW (5mA at 4V) to just put the display to sleep when the display is off.

Here is the reference of what the different settings of the modes do (for the st7789 anyway)
```
1. Normal Mode On (full display), Idle Mode Off, Sleep Out.
In this mode, the display is able to show maximum 262,144 colors.

2. Partial Mode On, Idle Mode Off, Sleep Out.
In this mode part of the display is used with maximum 262,144 colors.

3. Normal Mode On (full display), Idle Mode On, Sleep Out.
In this mode, the full display area is used but with 8 colors.

4. Partial Mode On, Idle Mode On, Sleep Out.
In this mode, part of the display is used but with 8 colors.

5. Sleep In Mode
In this mode, the DC: DC converter, internal oscillator and panel driver circuit are stopped. Only the MCU
```

Pretty simple PR since it was easy to add to the codebase but feel free to add any suggestions