### PR TITLE
add Display::is_sleeping fixes #77

### DIFF
--- a/mipidsi/CHANGELOG.md
+++ b/mipidsi/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - added `GC9A01` model support
 - added `Display::wake` method
 - added `Display::sleep` method
+- added `Display::is_sleeping` method
 
 ## [v0.7.1] - 2023-05-24
 

--- a/mipidsi/src/builder.rs
+++ b/mipidsi/src/builder.rs
@@ -140,6 +140,7 @@ where
             rst,
             options: self.options,
             madctl,
+            sleeping: false, // TODO: init should lock state
         };
 
         Ok(display)

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -259,7 +259,6 @@ where
 
     ///
     /// Returns `true` if display is currently set to sleep.
-    /// NOTE: value before call to `init` is considered undefined.
     ///
     pub fn is_sleeping<D: DelayUs<u32>>(&self) -> bool {
         self.sleeping


### PR DESCRIPTION
Adds a preliminary `is_sleeping` method. I'm not too happy about the state machine logic here though. I think we can merge this for the next version but I want to refactor things so that we can have a workable state machine for things like this that can properly tie into the Model inits etc.