### PR TITLE
Add new Orientation type and remove window_offset_handler

### DIFF
--- a/mipidsi/CHANGELOG.md
+++ b/mipidsi/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - DCS commands param fields are now all consistently private with added constructors for all such commands
 - DCS command constructors (such as `SetAddressMode::new`) are now marked as `const`, so DCS commands can be constructed in
   [const contexts](https://doc.rust-lang.org/reference/const_eval.html#const-context)
+- replaced `window_offset_handler` function pointer with `offset` field
+- default to disabled color inversion for all generic models
+
+### Removed
+
+- removed `Builder::with_framebuffer_size`
 
 ## [v0.7.1] - 2023-05-24
 

--- a/mipidsi/CHANGELOG.md
+++ b/mipidsi/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   [const contexts](https://doc.rust-lang.org/reference/const_eval.html#const-context)
 - replaced `window_offset_handler` function pointer with `offset` field
 - default to disabled color inversion for all generic models
+- renamed `Display::set_scroll_region` and `Display::set_scroll_offset` into `set_vertical_scroll_region` and `set_vertical_scroll_offset`
 
 ### Removed
 

--- a/mipidsi/src/builder.rs
+++ b/mipidsi/src/builder.rs
@@ -95,21 +95,10 @@ where
     }
 
     ///
-    /// Sets the framebuffer size
+    /// Sets the display offset
     ///
-    pub fn with_framebuffer_size(mut self, width: u16, height: u16) -> Self {
-        self.options.framebuffer_size = (width, height);
-        self
-    }
-
-    ///
-    /// Sets the window offset handler
-    ///
-    pub fn with_window_offset_handler(
-        mut self,
-        window_offset_handler: fn(_: &ModelOptions) -> (u16, u16),
-    ) -> Self {
-        self.options.window_offset_handler = window_offset_handler;
+    pub fn with_display_offset(mut self, x: u16, y: u16) -> Self {
+        self.options.display_offset = (x, y);
         self
     }
 

--- a/mipidsi/src/dcs/set_scroll_area.rs
+++ b/mipidsi/src/dcs/set_scroll_area.rs
@@ -47,7 +47,8 @@ impl From<&ModelOptions> for SetScrollArea {
     fn from(options: &ModelOptions) -> Self {
         Self {
             tfa: 0,
-            vsa: options.framebuffer_size_max(),
+            //vsa: options.framebuffer_size_max(),
+            vsa: 0, //TODO: fix
             bfa: 0,
         }
     }

--- a/mipidsi/src/dcs/set_scroll_area.rs
+++ b/mipidsi/src/dcs/set_scroll_area.rs
@@ -1,7 +1,6 @@
 //! Module for the VSCRDEF visual scroll definition instruction constructors
 
 use crate::error::Error;
-use crate::options::ModelOptions;
 
 use super::DcsCommand;
 
@@ -40,17 +39,6 @@ impl DcsCommand for SetScrollArea {
         buffer[5] = bfa_bytes[1];
 
         Ok(6)
-    }
-}
-
-impl From<&ModelOptions> for SetScrollArea {
-    fn from(options: &ModelOptions) -> Self {
-        Self {
-            tfa: 0,
-            //vsa: options.framebuffer_size_max(),
-            vsa: 0, //TODO: fix
-            bfa: 0,
-        }
     }
 }
 

--- a/mipidsi/src/graphics.rs
+++ b/mipidsi/src/graphics.rs
@@ -92,13 +92,6 @@ where
             Ok(())
         }
     }
-
-    fn clear(&mut self, color: Self::Color) -> Result<(), Self::Error> {
-        let fb_size = M::FRAMEBUFFER_SIZE;
-        let pixel_count = usize::from(fb_size.0) * usize::from(fb_size.1);
-        let colors = core::iter::repeat(color).take(pixel_count); // blank entire HW RAM contents
-        self.set_pixels(0, 0, fb_size.0 - 1, fb_size.1 - 1, colors)
-    }
 }
 
 impl<DI, MODEL, RST> OriginDimensions for Display<DI, MODEL, RST>

--- a/mipidsi/src/graphics.rs
+++ b/mipidsi/src/graphics.rs
@@ -1,6 +1,10 @@
-use embedded_graphics_core::prelude::{DrawTarget, Point, RgbColor, Size};
-use embedded_graphics_core::primitives::Rectangle;
-use embedded_graphics_core::{prelude::OriginDimensions, Pixel};
+use embedded_graphics_core::{
+    draw_target::DrawTarget,
+    geometry::{Dimensions, OriginDimensions, Size},
+    pixelcolor::RgbColor,
+    primitives::Rectangle,
+    Pixel,
+};
 use embedded_hal::digital::v2::OutputPin;
 
 use crate::dcs::BitsPerPixel;
@@ -67,12 +71,7 @@ where
     }
 
     fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
-        let fb_size = M::FRAMEBUFFER_SIZE;
-        let fb_rect = Rectangle::with_corners(
-            Point::new(0, 0),
-            Point::new(fb_size.0 as i32 - 1, fb_size.1 as i32 - 1),
-        );
-        let area = area.intersection(&fb_rect);
+        let area = area.intersection(&self.bounding_box());
 
         if let Some(bottom_right) = area.bottom_right() {
             let mut count = 0u32;

--- a/mipidsi/src/graphics.rs
+++ b/mipidsi/src/graphics.rs
@@ -67,7 +67,7 @@ where
     }
 
     fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
-        let fb_size = self.options.framebuffer_size();
+        let fb_size = M::FRAMEBUFFER_SIZE;
         let fb_rect = Rectangle::with_corners(
             Point::new(0, 0),
             Point::new(fb_size.0 as i32 - 1, fb_size.1 as i32 - 1),
@@ -95,7 +95,7 @@ where
     }
 
     fn clear(&mut self, color: Self::Color) -> Result<(), Self::Error> {
-        let fb_size = self.options.framebuffer_size();
+        let fb_size = M::FRAMEBUFFER_SIZE;
         let pixel_count = usize::from(fb_size.0) * usize::from(fb_size.1);
         let colors = core::iter::repeat(color).take(pixel_count); // blank entire HW RAM contents
         self.set_pixels(0, 0, fb_size.0 - 1, fb_size.1 - 1, colors)

--- a/mipidsi/src/models.rs
+++ b/mipidsi/src/models.rs
@@ -31,6 +31,9 @@ pub trait Model {
     /// The color format.
     type ColorFormat: RgbColor;
 
+    /// The framebuffer size in pixels.
+    const FRAMEBUFFER_SIZE: (u16, u16);
+
     /// Initializes the display for this model with MADCTL from [crate::Display]
     /// and returns the value of MADCTL set by init
     fn init<RST, DELAY, DI>(

--- a/mipidsi/src/models/gc9a01.rs
+++ b/mipidsi/src/models/gc9a01.rs
@@ -20,6 +20,7 @@ pub struct GC9A01;
 
 impl Model for GC9A01 {
     type ColorFormat = Rgb565;
+    const FRAMEBUFFER_SIZE: (u16, u16) = (240, 240);
 
     fn init<RST, DELAY, DI>(
         &mut self,
@@ -145,7 +146,7 @@ impl Model for GC9A01 {
     }
 
     fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((240, 240), (240, 240))
+        ModelOptions::full_size::<Self>()
     }
 }
 

--- a/mipidsi/src/models/ili9341.rs
+++ b/mipidsi/src/models/ili9341.rs
@@ -19,6 +19,7 @@ pub struct ILI9341Rgb666;
 
 impl Model for ILI9341Rgb565 {
     type ColorFormat = Rgb565;
+    const FRAMEBUFFER_SIZE: (u16, u16) = (240, 320);
 
     fn init<RST, DELAY, DI>(
         &mut self,
@@ -50,12 +51,13 @@ impl Model for ILI9341Rgb565 {
     }
 
     fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((240, 320), (240, 320))
+        ModelOptions::full_size::<Self>()
     }
 }
 
 impl Model for ILI9341Rgb666 {
     type ColorFormat = Rgb666;
+    const FRAMEBUFFER_SIZE: (u16, u16) = (240, 320);
 
     fn init<RST, DELAY, DI>(
         &mut self,
@@ -87,7 +89,7 @@ impl Model for ILI9341Rgb666 {
     }
 
     fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((240, 320), (240, 320))
+        ModelOptions::full_size::<Self>()
     }
 }
 

--- a/mipidsi/src/models/ili9342c.rs
+++ b/mipidsi/src/models/ili9342c.rs
@@ -19,6 +19,7 @@ pub struct ILI9342CRgb666;
 
 impl Model for ILI9342CRgb565 {
     type ColorFormat = Rgb565;
+    const FRAMEBUFFER_SIZE: (u16, u16) = (320, 240);
 
     fn init<RST, DELAY, DI>(
         &mut self,
@@ -50,12 +51,13 @@ impl Model for ILI9342CRgb565 {
     }
 
     fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((320, 240), (320, 240))
+        ModelOptions::full_size::<Self>()
     }
 }
 
 impl Model for ILI9342CRgb666 {
     type ColorFormat = Rgb666;
+    const FRAMEBUFFER_SIZE: (u16, u16) = (320, 240);
 
     fn init<RST, DELAY, DI>(
         &mut self,
@@ -87,7 +89,7 @@ impl Model for ILI9342CRgb666 {
     }
 
     fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((320, 240), (320, 240))
+        ModelOptions::full_size::<Self>()
     }
 }
 

--- a/mipidsi/src/models/ili9486.rs
+++ b/mipidsi/src/models/ili9486.rs
@@ -26,6 +26,7 @@ pub struct ILI9486Rgb666;
 
 impl Model for ILI9486Rgb565 {
     type ColorFormat = Rgb565;
+    const FRAMEBUFFER_SIZE: (u16, u16) = (320, 480);
 
     fn init<RST, DELAY, DI>(
         &mut self,
@@ -62,12 +63,13 @@ impl Model for ILI9486Rgb565 {
     }
 
     fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((320, 480), (320, 480))
+        ModelOptions::full_size::<Self>()
     }
 }
 
 impl Model for ILI9486Rgb666 {
     type ColorFormat = Rgb666;
+    const FRAMEBUFFER_SIZE: (u16, u16) = (320, 480);
 
     fn init<RST, DELAY, DI>(
         &mut self,
@@ -110,7 +112,7 @@ impl Model for ILI9486Rgb666 {
     }
 
     fn default_options() -> ModelOptions {
-        ModelOptions::with_sizes((320, 480), (320, 480))
+        ModelOptions::full_size::<Self>()
     }
 }
 

--- a/mipidsi/src/models/st7735s.rs
+++ b/mipidsi/src/models/st7735s.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     error::Error,
     error::InitError,
-    options::{ColorInversion, ModelOptions},
+    options::ModelOptions,
     Builder,
 };
 
@@ -20,6 +20,7 @@ pub struct ST7735s;
 
 impl Model for ST7735s {
     type ColorFormat = Rgb565;
+    const FRAMEBUFFER_SIZE: (u16, u16) = (132, 162);
 
     fn init<RST, DELAY, DI>(
         &mut self,
@@ -93,10 +94,7 @@ impl Model for ST7735s {
     }
 
     fn default_options() -> ModelOptions {
-        let mut options = ModelOptions::with_sizes((80, 160), (132, 162));
-        options.set_invert_colors(ColorInversion::Inverted);
-
-        options
+        ModelOptions::full_size::<Self>()
     }
 }
 

--- a/mipidsi/src/models/st7789.rs
+++ b/mipidsi/src/models/st7789.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     error::Error,
     error::InitError,
-    options::{ColorInversion, ModelOptions},
+    options::ModelOptions,
 };
 
 use super::Model;
@@ -24,6 +24,7 @@ pub struct ST7789;
 
 impl Model for ST7789 {
     type ColorFormat = Rgb565;
+    const FRAMEBUFFER_SIZE: (u16, u16) = (240, 320);
 
     fn init<RST, DELAY, DI>(
         &mut self,
@@ -82,9 +83,6 @@ impl Model for ST7789 {
     }
 
     fn default_options() -> ModelOptions {
-        let mut options = ModelOptions::with_sizes((240, 320), (240, 320));
-        options.set_invert_colors(ColorInversion::Normal);
-
-        options
+        ModelOptions::full_size::<Self>()
     }
 }

--- a/mipidsi/src/models/st7789.rs
+++ b/mipidsi/src/models/st7789.rs
@@ -5,7 +5,7 @@ use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 use crate::{
     dcs::{
         BitsPerPixel, Dcs, EnterNormalMode, ExitSleepMode, PixelFormat, SetAddressMode,
-        SetDisplayOn, SetInvertMode, SetPixelFormat, SetScrollArea, SoftReset, WriteMemoryStart,
+        SetDisplayOn, SetInvertMode, SetPixelFormat, SoftReset, WriteMemoryStart,
     },
     error::Error,
     error::InitError,
@@ -50,7 +50,6 @@ impl Model for ST7789 {
         delay.delay_us(10_000);
 
         // set hw scroll area based on framebuffer size
-        dcs.write_command(SetScrollArea::from(options))?;
         dcs.write_command(madctl)?;
 
         dcs.write_command(SetInvertMode::new(options.invert_colors))?;

--- a/mipidsi/src/models/st7789/variants.rs
+++ b/mipidsi/src/models/st7789/variants.rs
@@ -1,7 +1,7 @@
 use display_interface::WriteOnlyDataCommand;
 
 use crate::{
-    options::{ColorInversion, ModelOptions, Orientation},
+    options::{ColorInversion, ModelOptions},
     Builder,
 };
 
@@ -33,24 +33,10 @@ where
     /// * `di` - a [display interface](WriteOnlyDataCommand) for communicating with the display
     ///
     pub fn st7789_pico1(di: DI) -> Self {
-        let mut options = ModelOptions::with_all((135, 240), (135, 240), pico1_offset);
+        let mut options = ModelOptions::with_all((135, 240), (52, 40));
         options.set_invert_colors(ColorInversion::Inverted);
 
         // pico v1 is cropped to 135x240 size with an offset of (40, 53)
         Self::new(di, ST7789, options)
-    }
-}
-
-// ST7789 pico1 variant with variable offset
-pub(crate) fn pico1_offset(options: &ModelOptions) -> (u16, u16) {
-    match options.orientation() {
-        Orientation::Portrait(false) => (52, 40),
-        Orientation::Portrait(true) => (53, 40),
-        Orientation::Landscape(false) => (40, 52),
-        Orientation::Landscape(true) => (40, 53),
-        Orientation::PortraitInverted(false) => (53, 40),
-        Orientation::PortraitInverted(true) => (52, 40),
-        Orientation::LandscapeInverted(false) => (40, 53),
-        Orientation::LandscapeInverted(true) => (40, 52),
     }
 }

--- a/mipidsi/src/options.rs
+++ b/mipidsi/src/options.rs
@@ -1,5 +1,11 @@
 //! [ModelOptions] and other helper types.
 
+use crate::models::Model;
+
+mod orientation;
+pub(crate) use orientation::MemoryMapping;
+pub use orientation::{InvalidAngleError, Orientation, Rotation};
+
 /// [ModelOptions] holds the settings for [Model](crate::Model)s.
 ///
 /// `display_size` being set is the minimum requirement.
@@ -13,45 +19,34 @@ pub struct ModelOptions {
     pub(crate) invert_colors: ColorInversion,
     /// Display refresh order
     pub(crate) refresh_order: RefreshOrder,
-    /// Offset override function returning (w, h) offset for current
-    /// display orientation if display is "clipped" and needs an offset for (e.g. Pico v1)
-    pub(crate) window_offset_handler: fn(&ModelOptions) -> (u16, u16),
     /// Display size (w, h) for given display/model
     pub(crate) display_size: (u16, u16),
-    /// Framebuffer size (w, h) for given display/model
-    pub(crate) framebuffer_size: (u16, u16),
+    /// Display offset (x, y) for given display/model
+    pub(crate) display_offset: (u16, u16),
 }
 
 impl ModelOptions {
-    /// Creates model options for the given display and framebuffer sizes.
-    ///
-    /// All other settings are initialized to their default value.
-    pub fn with_sizes(display_size: (u16, u16), framebuffer_size: (u16, u16)) -> Self {
+    /// Creates model options for the entire framebuffer.
+    pub fn full_size<M: Model>() -> Self {
         Self {
             color_order: ColorOrder::default(),
             orientation: Orientation::default(),
             invert_colors: ColorInversion::default(),
             refresh_order: RefreshOrder::default(),
-            window_offset_handler: no_offset,
-            display_size,
-            framebuffer_size,
+            display_size: M::FRAMEBUFFER_SIZE,
+            display_offset: (0, 0),
         }
     }
 
-    /// Creates model options for the given sizes and offset handler.
-    pub fn with_all(
-        display_size: (u16, u16),
-        framebuffer_size: (u16, u16),
-        window_offset_handler: fn(&ModelOptions) -> (u16, u16),
-    ) -> Self {
+    /// Creates model options for the given size and offset.
+    pub fn with_all(display_size: (u16, u16), display_offset: (u16, u16)) -> Self {
         Self {
             color_order: ColorOrder::default(),
             orientation: Orientation::default(),
             invert_colors: ColorInversion::default(),
             refresh_order: RefreshOrder::default(),
-            window_offset_handler,
             display_size,
-            framebuffer_size,
+            display_offset,
         }
     }
 
@@ -64,36 +59,11 @@ impl ModelOptions {
     ///
     /// Used by models.
     pub(crate) fn display_size(&self) -> (u16, u16) {
-        Self::orient_size(self.display_size, self.orientation())
-    }
-
-    /// Returns framebuffer size based on current orientation and display options.
-    ///
-    /// Used by models. Uses display_size if framebuffer_size is not set.
-    pub(crate) fn framebuffer_size(&self) -> (u16, u16) {
-        let size = if self.framebuffer_size == (0, 0) {
+        if self.orientation.rotation.is_horizontal() {
             self.display_size
         } else {
-            self.framebuffer_size
-        };
-
-        Self::orient_size(size, self.orientation())
-    }
-
-    /// Returns the larger of framebuffer width or height.
-    ///
-    /// Used for scroll area setups.
-    pub(crate) fn framebuffer_size_max(&self) -> u16 {
-        let (w, h) = self.framebuffer_size();
-
-        w.max(h)
-    }
-
-    /// Returns window offset (x, y) based on current orientation and display options.
-    ///
-    /// Used by [Display::set_address_window](crate::Display::set_address_window).
-    pub(crate) fn window_offset(&mut self) -> (u16, u16) {
-        (self.window_offset_handler)(self)
+            (self.display_size.1, self.display_size.0)
+        }
     }
 
     /// Returns the current orientation.
@@ -104,60 +74,6 @@ impl ModelOptions {
     /// Sets the orientation.
     pub fn set_orientation(&mut self, orientation: Orientation) {
         self.orientation = orientation;
-    }
-
-    // Flip size according to orientation, in general
-    fn orient_size(size: (u16, u16), orientation: Orientation) -> (u16, u16) {
-        match orientation {
-            Orientation::Portrait(_) | Orientation::PortraitInverted(_) => size,
-            Orientation::Landscape(_) | Orientation::LandscapeInverted(_) => (size.1, size.0),
-        }
-    }
-}
-
-///
-/// `no_offset` is the default offset provider. It results to 0, 0 in case display_size is == framebuffer_size
-/// and to framebuffer_size - display_size otherwise.
-///
-fn no_offset(options: &ModelOptions) -> (u16, u16) {
-    // do FB size - Display size offset for inverted setups
-    match options.orientation {
-        Orientation::PortraitInverted(_) | Orientation::LandscapeInverted(_) => {
-            let hdiff = options.framebuffer_size.1 - options.display_size.1;
-
-            let mut x = 0;
-            let mut y = 0;
-
-            match options.orientation {
-                Orientation::PortraitInverted(_) => y = hdiff,
-                Orientation::LandscapeInverted(_) => x = hdiff,
-                _ => {}
-            }
-
-            (x, y)
-        }
-        _ => (0, 0),
-    }
-}
-
-///
-/// Display orientation.
-///
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Orientation {
-    /// Portrait orientation, with mirror image parameter
-    Portrait(bool),
-    /// Landscape orientation, with mirror image parameter
-    Landscape(bool),
-    /// Inverted Portrait orientation, with mirror image parameter
-    PortraitInverted(bool),
-    /// Inverted Lanscape orientation, with mirror image parameter
-    LandscapeInverted(bool),
-}
-
-impl Default for Orientation {
-    fn default() -> Self {
-        Self::Portrait(false)
     }
 }
 

--- a/mipidsi/src/options/orientation.rs
+++ b/mipidsi/src/options/orientation.rs
@@ -72,7 +72,7 @@ pub struct InvalidAngleError;
 /// # Examples
 ///
 /// ```
-/// use mipidsi::{Orientation, Rotation};
+/// use mipidsi::options::{Orientation, Rotation};
 ///
 /// // Rotate display content by 90 degree clockwise.
 /// let rotated = Orientation::new().rotate(Rotation::Deg90);
@@ -84,7 +84,7 @@ pub struct InvalidAngleError;
 /// Multiple transformations can be combined to build more complex orientations:
 ///
 /// ```
-/// use mipidsi::{Orientation, Rotation};
+/// use mipidsi::options::{Orientation, Rotation};
 ///
 /// let orientation = Orientation::new().rotate(Rotation::Deg270).flip_vertical();
 ///

--- a/mipidsi/src/options/orientation.rs
+++ b/mipidsi/src/options/orientation.rs
@@ -40,6 +40,7 @@ impl Rotation {
     }
 
     /// Rotates one rotation by another rotation.
+    #[must_use]
     pub const fn rotate(self, other: Rotation) -> Self {
         match Self::try_from_degree(self.degree() + other.degree()) {
             Ok(r) => r,
@@ -111,6 +112,7 @@ impl Orientation {
     }
 
     /// Rotates the orientation.
+    #[must_use]
     pub const fn rotate(self, rotation: Rotation) -> Self {
         Self {
             rotation: self.rotation.rotate(rotation),
@@ -119,6 +121,7 @@ impl Orientation {
     }
 
     /// Flips the orientation across the horizontal display axis.
+    #[must_use]
     const fn flip_horizontal_absolute(self) -> Self {
         Self {
             rotation: self.rotation,
@@ -127,6 +130,7 @@ impl Orientation {
     }
 
     /// Flips the orientation across the vertical display axis.
+    #[must_use]
     const fn flip_vertical_absolute(self) -> Self {
         Self {
             rotation: self.rotation.rotate(Rotation::Deg180),
@@ -135,6 +139,7 @@ impl Orientation {
     }
 
     /// Flips the orientation across the horizontal axis.
+    #[must_use]
     pub const fn flip_horizontal(self) -> Self {
         if self.rotation.is_vertical() {
             self.flip_vertical_absolute()
@@ -144,6 +149,7 @@ impl Orientation {
     }
 
     /// Flips the orientation across the vertical axis.
+    #[must_use]
     pub const fn flip_vertical(self) -> Self {
         if self.rotation.is_vertical() {
             self.flip_horizontal_absolute()

--- a/mipidsi/src/options/orientation.rs
+++ b/mipidsi/src/options/orientation.rs
@@ -1,0 +1,512 @@
+/// Display rotation.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Rotation {
+    /// No rotation.
+    Deg0,
+    /// 90° clockwise rotation.
+    Deg90,
+    /// 180° clockwise rotation.
+    Deg180,
+    /// 270° clockwise rotation.
+    Deg270,
+}
+
+impl Rotation {
+    /// Returns the rotation in degrees.
+    pub const fn degree(self) -> i32 {
+        match self {
+            Self::Deg0 => 0,
+            Self::Deg90 => 90,
+            Self::Deg180 => 180,
+            Self::Deg270 => 270,
+        }
+    }
+
+    /// Converts an angle into a rotation.
+    ///
+    /// Returns an error if the angle isn't an integer multiple of 90°.
+    pub const fn try_from_degree(mut angle: i32) -> Result<Self, InvalidAngleError> {
+        if angle < 0 || angle > 270 {
+            angle = angle.rem_euclid(360)
+        }
+
+        Ok(match angle {
+            0 => Self::Deg0,
+            90 => Self::Deg90,
+            180 => Self::Deg180,
+            270 => Self::Deg270,
+            _ => return Err(InvalidAngleError),
+        })
+    }
+
+    /// Rotates one rotation by another rotation.
+    pub const fn rotate(self, other: Rotation) -> Self {
+        match Self::try_from_degree(self.degree() + other.degree()) {
+            Ok(r) => r,
+            Err(_) => unreachable!(),
+        }
+    }
+
+    /// Returns `true` if the rotation is horizontal (0° or 180°).
+    pub const fn is_horizontal(self) -> bool {
+        matches!(self, Self::Deg0 | Self::Deg180)
+    }
+
+    /// Returns `true` if the rotation is vertical (90° or 270°).
+    pub const fn is_vertical(self) -> bool {
+        matches!(self, Self::Deg90 | Self::Deg270)
+    }
+}
+
+/// Invalid angle error.
+///
+/// The error type returned by [`Rotation::try_from_degree`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct InvalidAngleError;
+
+/// Display orientation.
+///
+/// A display orientation describes how the display content is oriented relative
+/// to the default orientation of the display.
+///
+/// # Examples
+///
+/// ```
+/// use mipidsi::{Orientation, Rotation};
+///
+/// // Rotate display content by 90 degree clockwise.
+/// let rotated = Orientation::new().rotate(Rotation::Deg90);
+///
+/// // Flip display content horizontally.
+/// let flipped = Orientation::new().flip_horizontal();
+/// ```
+///
+/// Multiple transformations can be combined to build more complex orientations:
+///
+/// ```
+/// use mipidsi::{Orientation, Rotation};
+///
+/// let orientation = Orientation::new().rotate(Rotation::Deg270).flip_vertical();
+///
+/// // Note that the order of operations is important:
+/// assert_ne!(orientation, Orientation::new().flip_vertical().rotate(Rotation::Deg270));
+/// assert_eq!(orientation, Orientation::new().flip_vertical().rotate(Rotation::Deg90));
+/// ```
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Orientation {
+    /// Rotation.
+    pub rotation: Rotation,
+    /// Mirrored.
+    pub mirrored: bool,
+}
+
+impl Orientation {
+    /// Creates a default orientation.
+    pub const fn new() -> Self {
+        Self {
+            rotation: Rotation::Deg0,
+            mirrored: false,
+        }
+    }
+
+    /// Rotates the orientation.
+    pub const fn rotate(self, rotation: Rotation) -> Self {
+        Self {
+            rotation: self.rotation.rotate(rotation),
+            mirrored: self.mirrored,
+        }
+    }
+
+    /// Flips the orientation across the horizontal display axis.
+    const fn flip_horizontal_absolute(self) -> Self {
+        Self {
+            rotation: self.rotation,
+            mirrored: !self.mirrored,
+        }
+    }
+
+    /// Flips the orientation across the vertical display axis.
+    const fn flip_vertical_absolute(self) -> Self {
+        Self {
+            rotation: self.rotation.rotate(Rotation::Deg180),
+            mirrored: !self.mirrored,
+        }
+    }
+
+    /// Flips the orientation across the horizontal axis.
+    pub const fn flip_horizontal(self) -> Self {
+        if self.rotation.is_vertical() {
+            self.flip_vertical_absolute()
+        } else {
+            self.flip_horizontal_absolute()
+        }
+    }
+
+    /// Flips the orientation across the vertical axis.
+    pub const fn flip_vertical(self) -> Self {
+        if self.rotation.is_vertical() {
+            self.flip_horizontal_absolute()
+        } else {
+            self.flip_vertical_absolute()
+        }
+    }
+}
+
+impl Default for Orientation {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Memory mapping.
+///
+/// A memory mapping describes how a framebuffer is mapped to the physical
+/// row and columns of a display.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MemoryMapping {
+    /// Rows and columns are swapped.
+    pub swap_rows_and_columns: bool,
+
+    /// Rows are reversed.
+    pub reverse_rows: bool,
+    /// Columns are reversed.
+    pub reverse_columns: bool,
+}
+
+impl MemoryMapping {
+    /// `const` variant of `From<Orientation>` impl.
+    pub const fn from_orientation(orientation: Orientation) -> Self {
+        let (reverse_rows, reverse_columns) = match orientation.rotation {
+            Rotation::Deg0 => (false, false),
+            Rotation::Deg90 => (false, true),
+            Rotation::Deg180 => (true, true),
+            Rotation::Deg270 => (true, false),
+        };
+
+        Self {
+            reverse_rows,
+            reverse_columns: reverse_columns ^ orientation.mirrored,
+            swap_rows_and_columns: orientation.rotation.is_vertical(),
+        }
+    }
+}
+
+impl From<Orientation> for MemoryMapping {
+    fn from(orientation: Orientation) -> Self {
+        Self::from_orientation(orientation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_from_degree() {
+        let mut expected = [
+            Rotation::Deg0,
+            Rotation::Deg90,
+            Rotation::Deg180,
+            Rotation::Deg270,
+        ]
+        .iter()
+        .copied()
+        .cycle();
+
+        for angle in (-720..=720).step_by(90) {
+            assert_eq!(
+                Rotation::try_from_degree(angle).unwrap(),
+                expected.next().unwrap(),
+                "{angle}"
+            );
+        }
+    }
+
+    #[test]
+    fn try_from_degree_error() {
+        assert_eq!(Rotation::try_from_degree(1), Err(InvalidAngleError));
+        assert_eq!(Rotation::try_from_degree(-1), Err(InvalidAngleError));
+        assert_eq!(Rotation::try_from_degree(i32::MIN), Err(InvalidAngleError));
+        assert_eq!(Rotation::try_from_degree(i32::MAX), Err(InvalidAngleError));
+    }
+
+    /// Abbreviated constructor for orientations.
+    const fn orientation(rotation: Rotation, mirrored: bool) -> Orientation {
+        Orientation { rotation, mirrored }
+    }
+
+    #[test]
+    fn flip_horizontal() {
+        use Rotation::*;
+
+        for ((rotation, mirrored), (expected_rotation, expected_mirrored)) in [
+            ((Deg0, false), (Deg0, true)),
+            ((Deg90, false), (Deg270, true)),
+            ((Deg180, false), (Deg180, true)),
+            ((Deg270, false), (Deg90, true)),
+            ((Deg0, true), (Deg0, false)),
+            ((Deg90, true), (Deg270, false)),
+            ((Deg180, true), (Deg180, false)),
+            ((Deg270, true), (Deg90, false)),
+        ]
+        .iter()
+        .copied()
+        {
+            assert_eq!(
+                orientation(rotation, mirrored).flip_horizontal(),
+                orientation(expected_rotation, expected_mirrored)
+            );
+        }
+    }
+
+    #[test]
+    fn flip_vertical() {
+        use Rotation::*;
+
+        for ((rotation, mirrored), (expected_rotation, expected_mirrored)) in [
+            ((Deg0, false), (Deg180, true)),
+            ((Deg90, false), (Deg90, true)),
+            ((Deg180, false), (Deg0, true)),
+            ((Deg270, false), (Deg270, true)),
+            ((Deg0, true), (Deg180, false)),
+            ((Deg90, true), (Deg90, false)),
+            ((Deg180, true), (Deg0, false)),
+            ((Deg270, true), (Deg270, false)),
+        ]
+        .iter()
+        .copied()
+        {
+            assert_eq!(
+                orientation(rotation, mirrored).flip_vertical(),
+                orientation(expected_rotation, expected_mirrored)
+            );
+        }
+    }
+
+    fn draw_memory_mapping(order: MemoryMapping) -> [[u8; 3]; 3] {
+        let mut buffer = [[0u8; 3]; 3];
+
+        let (max_x, max_y) = if order.swap_rows_and_columns {
+            (1, 2)
+        } else {
+            (2, 1)
+        };
+
+        let mut i = 1..;
+        for y in 0..2 {
+            for x in 0..3 {
+                let (x, y) = if order.swap_rows_and_columns {
+                    (y, x)
+                } else {
+                    (x, y)
+                };
+                let x = if order.reverse_columns { max_x - x } else { x };
+                let y = if order.reverse_rows { max_y - y } else { y };
+
+                buffer[y as usize][x as usize] = i.next().unwrap();
+            }
+        }
+
+        buffer
+    }
+
+    #[test]
+    fn test_draw_memory_mapping() {
+        assert_eq!(
+            &draw_memory_mapping(MemoryMapping {
+                reverse_rows: false,
+                reverse_columns: false,
+                swap_rows_and_columns: false,
+            }),
+            &[
+                [1, 2, 3], //
+                [4, 5, 6], //
+                [0, 0, 0], //
+            ]
+        );
+
+        assert_eq!(
+            &draw_memory_mapping(MemoryMapping {
+                reverse_rows: true,
+                reverse_columns: false,
+                swap_rows_and_columns: false,
+            }),
+            &[
+                [4, 5, 6], //
+                [1, 2, 3], //
+                [0, 0, 0], //
+            ]
+        );
+
+        assert_eq!(
+            &draw_memory_mapping(MemoryMapping {
+                reverse_rows: false,
+                reverse_columns: true,
+                swap_rows_and_columns: false,
+            }),
+            &[
+                [3, 2, 1], //
+                [6, 5, 4], //
+                [0, 0, 0], //
+            ]
+        );
+
+        assert_eq!(
+            &draw_memory_mapping(MemoryMapping {
+                reverse_rows: true,
+                reverse_columns: true,
+                swap_rows_and_columns: false,
+            }),
+            &[
+                [6, 5, 4], //
+                [3, 2, 1], //
+                [0, 0, 0], //
+            ]
+        );
+
+        assert_eq!(
+            &draw_memory_mapping(MemoryMapping {
+                reverse_rows: false,
+                reverse_columns: false,
+                swap_rows_and_columns: true,
+            }),
+            &[
+                [1, 4, 0], //
+                [2, 5, 0], //
+                [3, 6, 0], //
+            ]
+        );
+
+        assert_eq!(
+            &draw_memory_mapping(MemoryMapping {
+                reverse_rows: true,
+                reverse_columns: false,
+                swap_rows_and_columns: true,
+            }),
+            &[
+                [3, 6, 0], //
+                [2, 5, 0], //
+                [1, 4, 0], //
+            ]
+        );
+
+        assert_eq!(
+            &draw_memory_mapping(MemoryMapping {
+                reverse_rows: false,
+                reverse_columns: true,
+                swap_rows_and_columns: true,
+            }),
+            &[
+                [4, 1, 0], //
+                [5, 2, 0], //
+                [6, 3, 0], //
+            ]
+        );
+
+        assert_eq!(
+            &draw_memory_mapping(MemoryMapping {
+                reverse_rows: true,
+                reverse_columns: true,
+                swap_rows_and_columns: true,
+            }),
+            &[
+                [6, 3, 0], //
+                [5, 2, 0], //
+                [4, 1, 0], //
+            ]
+        );
+    }
+
+    #[test]
+    fn into_memory_order_not_mirrored() {
+        assert_eq!(
+            &draw_memory_mapping(orientation(Rotation::Deg0, false).into()),
+            &[
+                [1, 2, 3], //
+                [4, 5, 6], //
+                [0, 0, 0], //
+            ]
+        );
+
+        assert_eq!(
+            &draw_memory_mapping(orientation(Rotation::Deg90, false).into()),
+            &[
+                [4, 1, 0], //
+                [5, 2, 0], //
+                [6, 3, 0], //
+            ]
+        );
+
+        assert_eq!(
+            &draw_memory_mapping(orientation(Rotation::Deg180, false).into()),
+            &[
+                [6, 5, 4], //
+                [3, 2, 1], //
+                [0, 0, 0], //
+            ]
+        );
+
+        assert_eq!(
+            &draw_memory_mapping(orientation(Rotation::Deg270, false).into()),
+            &[
+                [3, 6, 0], //
+                [2, 5, 0], //
+                [1, 4, 0], //
+            ]
+        );
+    }
+
+    #[test]
+    fn into_memory_order_mirrored() {
+        assert_eq!(
+            &draw_memory_mapping(orientation(Rotation::Deg0, true).into()),
+            &[
+                [3, 2, 1], //
+                [6, 5, 4], //
+                [0, 0, 0], //
+            ]
+        );
+
+        assert_eq!(
+            &draw_memory_mapping(orientation(Rotation::Deg90, true).into()),
+            &[
+                [1, 4, 0], //
+                [2, 5, 0], //
+                [3, 6, 0], //
+            ]
+        );
+
+        assert_eq!(
+            &draw_memory_mapping(orientation(Rotation::Deg180, true).into()),
+            &[
+                [4, 5, 6], //
+                [1, 2, 3], //
+                [0, 0, 0], //
+            ]
+        );
+
+        assert_eq!(
+            &draw_memory_mapping(orientation(Rotation::Deg270, true).into()),
+            &[
+                [6, 3, 0], //
+                [5, 2, 0], //
+                [4, 1, 0], //
+            ]
+        );
+    }
+
+    #[test]
+    fn equivalent_orientations() {
+        let o1 = Orientation::new().rotate(Rotation::Deg270).flip_vertical();
+        let o2 = Orientation::new().rotate(Rotation::Deg90).flip_horizontal();
+        let o3 = Orientation::new()
+            .flip_horizontal()
+            .rotate(Rotation::Deg270);
+        let o4 = Orientation::new().flip_vertical().rotate(Rotation::Deg90);
+
+        assert_eq!(o1, o2);
+        assert_eq!(o1, o3);
+        assert_eq!(o1, o4);
+    }
+}


### PR DESCRIPTION
This PR adds the `Orientation` and `Rotation` types, which were originally intended to be added to the `display-driver-hal` crate. I don't think that crate will be released any time soon, because there didn't seem to be any interest from other driver authors. But I think the new types are easier to use and we can still extract them into another crate later.

There was at least one orientation which didn't work correctly in the previous implementation, which should be fixed now. I don't remember the details, but I think one orientation was mirrored, even without setting the boolean mirrored flag.

I also decided to remove the `window_offset_handler` as a part of these changes, because I had to modify the code anyway. Instead of a handler there are now two settings, one for the display size and one for the offset. The framebuffer size is constant for every controller and is now a new `const` in the `Model` trait.

The PR is marked as a draft at the moment, because I still need to tweak/test a few things:
- [x] Fix `SetScrollArea`
- [ ] Set default offset to `framebuffer_size - display_size / 2`
- [ ] Remove `default_options`? This would require separate struct/traits for models and controller, like I suggested in #53.