### PR TITLE
Update for embedded-hal 1.0.0-rc.1

### DIFF
--- a/mipidsi-async/Cargo.toml
+++ b/mipidsi-async/Cargo.toml
@@ -12,14 +12,13 @@ documentation = "https://docs.rs/mipidsi"
 rust-version = "1.61"
 
 [dependencies]
-display-interface = "0.4.1"
-embedded-graphics-core = "0.4.0"
-embedded-hal = "0.2.7"
-nb = "1.0.0"
+display-interface = { git = "https://github.com/therealprof/display-interface.git" }
+embedded-graphics-core = ">= 0.4.0"
+embedded-hal = "1.0.0-rc.1"
 
 [dependencies.heapless]
 optional = true
-version = "0.7.16"
+version = ">= 0.7.16"
 
 [features]
 default = ["batch"]

--- a/mipidsi/Cargo.toml
+++ b/mipidsi/Cargo.toml
@@ -12,14 +12,13 @@ documentation = "https://docs.rs/mipidsi"
 rust-version = "1.61"
 
 [dependencies]
-display-interface = "0.4.1"
-embedded-graphics-core = "0.4.0"
-embedded-hal = "0.2.7"
-nb = "1.0.0"
+display-interface = { git = "https://github.com/therealprof/display-interface.git" }
+embedded-graphics-core = ">= 0.4.0"
+embedded-hal = "1.0.0-rc.1"
 
 [dependencies.heapless]
 optional = true
-version = "0.7.16"
+version = ">= 0.7.16"
 
 [features]
 default = ["batch"]

--- a/mipidsi/src/batch.rs
+++ b/mipidsi/src/batch.rs
@@ -4,7 +4,7 @@
 use crate::{models::Model, Display, Error};
 use display_interface::WriteOnlyDataCommand;
 use embedded_graphics_core::prelude::*;
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::digital::OutputPin;
 
 pub trait DrawBatch<DI, M, I>
 where

--- a/mipidsi/src/builder.rs
+++ b/mipidsi/src/builder.rs
@@ -1,7 +1,7 @@
 //! [super::Display] builder module
 
 use display_interface::WriteOnlyDataCommand;
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::Dcs, error::InitError, models::Model, ColorInversion, ColorOrder, Display, ModelOptions,
@@ -124,7 +124,7 @@ where
     /// If it wasn't provided the user needs to ensure this is the case.
     pub fn init<RST>(
         mut self,
-        delay_source: &mut impl DelayUs<u32>,
+        delay_source: &mut impl DelayUs,
         mut rst: Option<RST>,
     ) -> Result<Display<DI, MODEL, RST>, InitError<RST::Error>>
     where

--- a/mipidsi/src/error.rs
+++ b/mipidsi/src/error.rs
@@ -7,7 +7,7 @@ use display_interface::DisplayError;
 pub enum InitError<PE> {
     /// Error caused by the display interface.
     DisplayError,
-    /// Error caused by the reset pin's [`OutputPin`](embedded_hal::digital::v2::OutputPin) implementation.
+    /// Error caused by the reset pin's [`OutputPin`](embedded_hal::digital::OutputPin) implementation.
     Pin(PE),
 }
 

--- a/mipidsi/src/graphics.rs
+++ b/mipidsi/src/graphics.rs
@@ -1,7 +1,7 @@
 use embedded_graphics_core::prelude::{DrawTarget, Point, RgbColor, Size};
 use embedded_graphics_core::primitives::Rectangle;
 use embedded_graphics_core::{prelude::OriginDimensions, Pixel};
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::digital::OutputPin;
 
 use crate::dcs::BitsPerPixel;
 use crate::models::Model;

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -80,8 +80,8 @@ use dcs::Dcs;
 use display_interface::WriteOnlyDataCommand;
 
 pub mod error;
-use embedded_hal::blocking::delay::DelayUs;
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::delay::DelayUs;
+use embedded_hal::digital::OutputPin;
 pub use error::Error;
 
 pub mod options;
@@ -263,7 +263,7 @@ where
     ///
     /// Returns `true` if display is currently set to sleep.
     ///
-    pub fn is_sleeping<D: DelayUs<u32>>(&self) -> bool {
+    pub fn is_sleeping<D: DelayUs>(&self) -> bool {
         self.sleeping
     }
 
@@ -271,7 +271,7 @@ where
     /// Puts the display to sleep, reducing power consumption.
     /// Need to call [Self::wake] before issuing other commands
     ///
-    pub fn sleep<D: DelayUs<u32>>(&mut self, delay: &mut D) -> Result<(), Error> {
+    pub fn sleep<D: DelayUs>(&mut self, delay: &mut D) -> Result<(), Error> {
         self.dcs.write_command(dcs::EnterSleepMode)?;
         // All supported models requires a 120ms delay before issuing other commands
         delay.delay_us(120_000);
@@ -282,7 +282,7 @@ where
     ///
     /// Wakes the display after it's been set to sleep via [Self::sleep]
     ///
-    pub fn wake<D: DelayUs<u32>>(&mut self, delay: &mut D) -> Result<(), Error> {
+    pub fn wake<D: DelayUs>(&mut self, delay: &mut D) -> Result<(), Error> {
         self.dcs.write_command(dcs::ExitSleepMode)?;
         // ST7789 and st7735s have the highest minimal delay of 120ms
         delay.delay_us(120_000);

--- a/mipidsi/src/models.rs
+++ b/mipidsi/src/models.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use display_interface::WriteOnlyDataCommand;
 use embedded_graphics_core::prelude::RgbColor;
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 // existing model implementations
 mod gc9a01;
@@ -41,7 +41,7 @@ pub trait Model {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand;
 
     /// Resets the display using a reset pin.
@@ -52,7 +52,7 @@ pub trait Model {
     ) -> Result<(), InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
     {
         rst.set_low().map_err(InitError::Pin)?;
         delay.delay_us(10);

--- a/mipidsi/src/models/gc9a01.rs
+++ b/mipidsi/src/models/gc9a01.rs
@@ -1,6 +1,6 @@
 use display_interface::{DataFormat, WriteOnlyDataCommand};
 use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{
@@ -28,7 +28,7 @@ impl Model for GC9A01 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         let madctl = SetAddressMode::from(options);

--- a/mipidsi/src/models/ili9341.rs
+++ b/mipidsi/src/models/ili9341.rs
@@ -1,6 +1,6 @@
 use display_interface::WriteOnlyDataCommand;
 use embedded_graphics_core::pixelcolor::{Rgb565, Rgb666};
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{BitsPerPixel, Dcs, PixelFormat, SetAddressMode, SoftReset},
@@ -27,7 +27,7 @@ impl Model for ILI9341Rgb565 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {
@@ -64,7 +64,7 @@ impl Model for ILI9341Rgb666 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {

--- a/mipidsi/src/models/ili9342c.rs
+++ b/mipidsi/src/models/ili9342c.rs
@@ -1,6 +1,6 @@
 use display_interface::WriteOnlyDataCommand;
 use embedded_graphics_core::pixelcolor::{Rgb565, Rgb666};
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{BitsPerPixel, Dcs, PixelFormat, SetAddressMode, SoftReset},
@@ -27,7 +27,7 @@ impl Model for ILI9342CRgb565 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {
@@ -64,7 +64,7 @@ impl Model for ILI9342CRgb666 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {

--- a/mipidsi/src/models/ili934x.rs
+++ b/mipidsi/src/models/ili934x.rs
@@ -1,6 +1,6 @@
 use display_interface::{DataFormat, WriteOnlyDataCommand};
 use embedded_graphics_core::pixelcolor::{IntoStorage, Rgb565, Rgb666, RgbColor};
-use embedded_hal::blocking::delay::DelayUs;
+use embedded_hal::delay::DelayUs;
 
 use crate::{
     dcs::{
@@ -18,7 +18,7 @@ pub fn init_common<DELAY, DI>(
     pixel_format: PixelFormat,
 ) -> Result<SetAddressMode, Error>
 where
-    DELAY: DelayUs<u32>,
+    DELAY: DelayUs,
     DI: WriteOnlyDataCommand,
 {
     let madctl = SetAddressMode::from(options);

--- a/mipidsi/src/models/ili9486.rs
+++ b/mipidsi/src/models/ili9486.rs
@@ -3,7 +3,7 @@ use embedded_graphics_core::{
     pixelcolor::{Rgb565, Rgb666},
     prelude::{IntoStorage, RgbColor},
 };
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{
@@ -34,7 +34,7 @@ impl Model for ILI9486Rgb565 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {
@@ -76,7 +76,7 @@ impl Model for ILI9486Rgb666 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         match rst {
@@ -160,7 +160,7 @@ fn init_common<DELAY, DI>(
     pixel_format: PixelFormat,
 ) -> Result<SetAddressMode, Error>
 where
-    DELAY: DelayUs<u32>,
+    DELAY: DelayUs,
     DI: WriteOnlyDataCommand,
 {
     let madctl = SetAddressMode::from(options);

--- a/mipidsi/src/models/st7735s.rs
+++ b/mipidsi/src/models/st7735s.rs
@@ -1,6 +1,6 @@
 use display_interface::{DataFormat, WriteOnlyDataCommand};
 use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{
@@ -28,7 +28,7 @@ impl Model for ST7735s {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         let madctl = SetAddressMode::from(options);

--- a/mipidsi/src/models/st7789.rs
+++ b/mipidsi/src/models/st7789.rs
@@ -1,6 +1,6 @@
 use display_interface::{DataFormat, WriteOnlyDataCommand};
 use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 use crate::{
     dcs::{
@@ -33,7 +33,7 @@ impl Model for ST7789 {
     ) -> Result<SetAddressMode, InitError<RST::Error>>
     where
         RST: OutputPin,
-        DELAY: DelayUs<u32>,
+        DELAY: DelayUs,
         DI: WriteOnlyDataCommand,
     {
         let madctl = SetAddressMode::from(options);


### PR DESCRIPTION
There are ways to support EH1 and EH 0.2.7 simultaneously.  This PR is just to make EH1 support available ASAP to interested parties.  I haven't thought much about downstream effects yet.