### PR TITLE
make Display::dcs public, fixes #89

### DIFF
--- a/mipidsi/CHANGELOG.md
+++ b/mipidsi/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - added `Display::sleep` method
 - added `Display::is_sleeping` method
 
+### Changed
+
+- exposed `Display::dcs` to allow sending custom DCS commands to the device
+
 ## [v0.7.1] - 2023-05-24
 
 ### Changed

--- a/mipidsi/CHANGELOG.md
+++ b/mipidsi/CHANGELOG.md
@@ -13,10 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - added `Display::wake` method
 - added `Display::sleep` method
 - added `Display::is_sleeping` method
-
-### Changed
-
-- exposed `Display::dcs` to allow sending custom DCS commands to the device
+- added `Display::dcs` method to allow sending custom DCS commands to the device
 
 ## [v0.7.1] - 2023-05-24
 

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -112,8 +112,8 @@ where
     MODEL: Model,
     RST: OutputPin,
 {
-    /// DCS provider, can be used directly to send custom DCS commands to the device
-    pub dcs: Dcs<DI>,
+    // DCS provider
+    dcs: Dcs<DI>,
     // Model
     model: MODEL,
     // Reset pin
@@ -288,5 +288,13 @@ where
         delay.delay_us(120_000);
         self.sleeping = false;
         Ok(())
+    }
+
+    ///
+    /// Returns the DCS interface for sending raw commands.
+    /// *WARNING*: user is responsible for ensuring display state validity
+    ///
+    pub unsafe fn dcs(&mut self) -> &mut Dcs<DI> {
+        &mut self.dcs
     }
 }

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -290,10 +290,14 @@ where
         Ok(())
     }
 
-    ///
     /// Returns the DCS interface for sending raw commands.
-    /// *WARNING*: user is responsible for ensuring display state validity
     ///
+    /// # Safety
+    ///
+    /// Sending raw commands to the controller can lead to undefined behaviour,
+    /// because the rest of the code isn't aware of any state changes that were caused by sending raw commands.
+    /// The user must ensure that the state of the controller isn't altered in a way that interferes with the normal
+    /// operation of this crate.
     pub unsafe fn dcs(&mut self) -> &mut Dcs<DI> {
         &mut self.dcs
     }

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -112,8 +112,8 @@ where
     MODEL: Model,
     RST: OutputPin,
 {
-    // DCS provider
-    dcs: Dcs<DI>,
+    /// DCS provider, can be used directly to send custom DCS commands to the device
+    pub dcs: Dcs<DI>,
     // Model
     model: MODEL,
     // Reset pin


### PR DESCRIPTION
Add `Display::dcs` `unsafe` method to allow sending custom commands. Fixes #89 