### PR TITLE
do not re-exports sub-types from submodules, fixes #95

### DIFF
--- a/mipidsi/src/batch.rs
+++ b/mipidsi/src/batch.rs
@@ -1,7 +1,7 @@
 //! Original code from: [this repo](https://github.com/lupyuen/piet-embedded/blob/master/piet-embedded-graphics/src/batch.rs)
 //! Batch the pixels to be rendered into Pixel Rows and Pixel Blocks (contiguous Pixel Rows).
 //! This enables the pixels to be rendered efficiently as Pixel Blocks, which may be transmitted in a single Non-Blocking SPI request.
-use crate::{models::Model, Display, Error};
+use crate::{error::Error, models::Model, Display};
 use display_interface::WriteOnlyDataCommand;
 use embedded_graphics_core::prelude::*;
 use embedded_hal::digital::v2::OutputPin;

--- a/mipidsi/src/builder.rs
+++ b/mipidsi/src/builder.rs
@@ -3,10 +3,9 @@
 use display_interface::WriteOnlyDataCommand;
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
-use crate::{
-    dcs::Dcs, error::InitError, models::Model, ColorInversion, ColorOrder, Display, ModelOptions,
-    Orientation, RefreshOrder,
-};
+use crate::{dcs::Dcs, error::InitError, models::Model, Display};
+
+use crate::options::{ColorInversion, ColorOrder, ModelOptions, Orientation, RefreshOrder};
 
 /// Builder for [Display] instances.
 ///

--- a/mipidsi/src/dcs.rs
+++ b/mipidsi/src/dcs.rs
@@ -2,7 +2,7 @@
 
 use display_interface::{DataFormat, WriteOnlyDataCommand};
 
-use crate::Error;
+use crate::error::Error;
 
 #[macro_use]
 mod macros;

--- a/mipidsi/src/dcs/set_address_mode.rs
+++ b/mipidsi/src/dcs/set_address_mode.rs
@@ -1,7 +1,8 @@
 //! Module for the MADCTL instruction constructors
 
-use crate::{
-    ColorOrder, Error, HorizontalRefreshOrder, ModelOptions, Orientation, RefreshOrder,
+use crate::error::Error;
+use crate::options::{
+    ColorOrder, HorizontalRefreshOrder, ModelOptions, Orientation, RefreshOrder,
     VerticalRefreshOrder,
 };
 

--- a/mipidsi/src/dcs/set_column_address.rs
+++ b/mipidsi/src/dcs/set_column_address.rs
@@ -1,6 +1,6 @@
 //! Module for the CASET address window instruction constructors
 
-use crate::Error;
+use crate::error::Error;
 
 use super::DcsCommand;
 

--- a/mipidsi/src/dcs/set_invert_mode.rs
+++ b/mipidsi/src/dcs/set_invert_mode.rs
@@ -1,4 +1,5 @@
-use crate::{ColorInversion, Error};
+use crate::error::Error;
+use crate::options::ColorInversion;
 
 use super::DcsCommand;
 

--- a/mipidsi/src/dcs/set_page_address.rs
+++ b/mipidsi/src/dcs/set_page_address.rs
@@ -1,6 +1,6 @@
 //! Module for the RASET address window instruction constructors
 
-use crate::Error;
+use crate::error::Error;
 
 use super::DcsCommand;
 

--- a/mipidsi/src/dcs/set_pixel_format.rs
+++ b/mipidsi/src/dcs/set_pixel_format.rs
@@ -1,6 +1,6 @@
 //! Module for the COLMOD instruction constructors
 
-use crate::Error;
+use crate::error::Error;
 
 use super::DcsCommand;
 

--- a/mipidsi/src/dcs/set_scroll_area.rs
+++ b/mipidsi/src/dcs/set_scroll_area.rs
@@ -1,6 +1,7 @@
 //! Module for the VSCRDEF visual scroll definition instruction constructors
 
-use crate::{Error, ModelOptions};
+use crate::error::Error;
+use crate::options::ModelOptions;
 
 use super::DcsCommand;
 

--- a/mipidsi/src/dcs/set_scroll_start.rs
+++ b/mipidsi/src/dcs/set_scroll_start.rs
@@ -1,6 +1,6 @@
 //! Module for the VSCAD visual scroll offset instruction constructors
 
-use crate::Error;
+use crate::error::Error;
 
 use super::DcsCommand;
 

--- a/mipidsi/src/dcs/set_tearing_effect.rs
+++ b/mipidsi/src/dcs/set_tearing_effect.rs
@@ -1,4 +1,5 @@
-use crate::{Error, TearingEffect};
+use crate::error::Error;
+use crate::options::TearingEffect;
 
 use super::DcsCommand;
 

--- a/mipidsi/src/graphics.rs
+++ b/mipidsi/src/graphics.rs
@@ -5,7 +5,7 @@ use embedded_hal::digital::v2::OutputPin;
 
 use crate::dcs::BitsPerPixel;
 use crate::models::Model;
-use crate::{Display, Error};
+use crate::{error::Error, Display};
 use display_interface::WriteOnlyDataCommand;
 
 impl<DI, M, RST> DrawTarget for Display<DI, M, RST>

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -80,12 +80,12 @@ use dcs::Dcs;
 use display_interface::WriteOnlyDataCommand;
 
 pub mod error;
+use error::Error;
+
 use embedded_hal::blocking::delay::DelayUs;
 use embedded_hal::digital::v2::OutputPin;
-pub use error::Error;
 
 pub mod options;
-pub use options::*;
 
 mod builder;
 pub use builder::Builder;
@@ -119,7 +119,7 @@ where
     // Reset pin
     rst: Option<RST>,
     // Model Options, includes current orientation
-    options: ModelOptions,
+    options: options::ModelOptions,
     // Current MADCTL value copy for runtime updates
     madctl: dcs::SetAddressMode,
     // State monitor for sleeping TODO: refactor to a Model-connected state machine
@@ -135,7 +135,7 @@ where
     ///
     /// Returns currently set [Orientation]
     ///
-    pub fn orientation(&self) -> Orientation {
+    pub fn orientation(&self) -> options::Orientation {
         self.options.orientation()
     }
 
@@ -146,7 +146,7 @@ where
     /// ```rust ignore
     /// display.orientation(Orientation::Portrait(false)).unwrap();
     /// ```
-    pub fn set_orientation(&mut self, orientation: Orientation) -> Result<(), Error> {
+    pub fn set_orientation(&mut self, orientation: options::Orientation) -> Result<(), Error> {
         self.madctl = self.madctl.with_orientation(orientation); // set orientation
         self.dcs.write_command(self.madctl)?;
 
@@ -255,7 +255,10 @@ where
     ///
     /// Configures the tearing effect output.
     ///
-    pub fn set_tearing_effect(&mut self, tearing_effect: TearingEffect) -> Result<(), Error> {
+    pub fn set_tearing_effect(
+        &mut self,
+        tearing_effect: options::TearingEffect,
+    ) -> Result<(), Error> {
         self.dcs
             .write_command(dcs::SetTearingEffect::new(tearing_effect))
     }

--- a/mipidsi/src/models.rs
+++ b/mipidsi/src/models.rs
@@ -2,8 +2,9 @@
 
 use crate::{
     dcs::{Dcs, SetAddressMode},
+    error::Error,
     error::InitError,
-    Error, ModelOptions,
+    options::ModelOptions,
 };
 use display_interface::WriteOnlyDataCommand;
 use embedded_graphics_core::prelude::RgbColor;

--- a/mipidsi/src/models/gc9a01.rs
+++ b/mipidsi/src/models/gc9a01.rs
@@ -7,8 +7,10 @@ use crate::{
         BitsPerPixel, ExitSleepMode, PixelFormat, SetAddressMode, SetDisplayOn, SetInvertMode,
         SetPixelFormat, SoftReset, WriteMemoryStart,
     },
+    error::Error,
     error::InitError,
-    Builder, Error, ModelOptions,
+    options::ModelOptions,
+    Builder,
 };
 
 use super::{Dcs, Model};

--- a/mipidsi/src/models/ili9341.rs
+++ b/mipidsi/src/models/ili9341.rs
@@ -4,9 +4,11 @@ use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 use crate::{
     dcs::{BitsPerPixel, Dcs, PixelFormat, SetAddressMode, SoftReset},
+    error::Error,
     error::InitError,
     models::{ili934x, Model},
-    Builder, Error, ModelOptions,
+    options::ModelOptions,
+    Builder,
 };
 
 /// ILI9341 display in Rgb565 color mode.

--- a/mipidsi/src/models/ili9342c.rs
+++ b/mipidsi/src/models/ili9342c.rs
@@ -4,9 +4,11 @@ use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 use crate::{
     dcs::{BitsPerPixel, Dcs, PixelFormat, SetAddressMode, SoftReset},
+    error::Error,
     error::InitError,
     models::{ili934x, Model},
-    Builder, Error, ModelOptions,
+    options::ModelOptions,
+    Builder,
 };
 
 /// ILI9342C display in Rgb565 color mode.

--- a/mipidsi/src/models/ili934x.rs
+++ b/mipidsi/src/models/ili934x.rs
@@ -7,7 +7,8 @@ use crate::{
         Dcs, EnterNormalMode, ExitSleepMode, PixelFormat, SetAddressMode, SetDisplayOn,
         SetInvertMode, SetPixelFormat, WriteMemoryStart,
     },
-    Error, ModelOptions,
+    error::Error,
+    options::ModelOptions,
 };
 
 /// Common init for all ILI934x controllers and color formats.

--- a/mipidsi/src/models/ili9486.rs
+++ b/mipidsi/src/models/ili9486.rs
@@ -10,8 +10,10 @@ use crate::{
         BitsPerPixel, Dcs, EnterNormalMode, ExitSleepMode, PixelFormat, SetAddressMode,
         SetDisplayOn, SetInvertMode, SetPixelFormat, SoftReset, WriteMemoryStart,
     },
+    error::Error,
     error::InitError,
-    Builder, Error, ModelOptions,
+    options::ModelOptions,
+    Builder,
 };
 
 use super::Model;

--- a/mipidsi/src/models/st7735s.rs
+++ b/mipidsi/src/models/st7735s.rs
@@ -7,8 +7,10 @@ use crate::{
         BitsPerPixel, ExitSleepMode, PixelFormat, SetAddressMode, SetDisplayOn, SetInvertMode,
         SetPixelFormat, SoftReset, WriteMemoryStart,
     },
+    error::Error,
     error::InitError,
-    Builder, ColorInversion, Error, ModelOptions,
+    options::{ColorInversion, ModelOptions},
+    Builder,
 };
 
 use super::{Dcs, Model};

--- a/mipidsi/src/models/st7789.rs
+++ b/mipidsi/src/models/st7789.rs
@@ -7,8 +7,9 @@ use crate::{
         BitsPerPixel, Dcs, EnterNormalMode, ExitSleepMode, PixelFormat, SetAddressMode,
         SetDisplayOn, SetInvertMode, SetPixelFormat, SetScrollArea, SoftReset, WriteMemoryStart,
     },
+    error::Error,
     error::InitError,
-    ColorInversion, Error, ModelOptions,
+    options::{ColorInversion, ModelOptions},
 };
 
 use super::Model;
@@ -80,7 +81,7 @@ impl Model for ST7789 {
         Ok(())
     }
 
-    fn default_options() -> crate::ModelOptions {
+    fn default_options() -> ModelOptions {
         let mut options = ModelOptions::with_sizes((240, 320), (240, 320));
         options.set_invert_colors(ColorInversion::Normal);
 

--- a/mipidsi/src/models/st7789/variants.rs
+++ b/mipidsi/src/models/st7789/variants.rs
@@ -1,6 +1,9 @@
 use display_interface::WriteOnlyDataCommand;
 
-use crate::{Builder, ColorInversion, ModelOptions, Orientation};
+use crate::{
+    options::{ColorInversion, ModelOptions, Orientation},
+    Builder,
+};
 
 use super::ST7789;
 


### PR DESCRIPTION
Removes the re-exports of submodule types