### PR TITLE
Remove Model::default_options

### DIFF
--- a/mipidsi/CHANGELOG.md
+++ b/mipidsi/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - replaced `window_offset_handler` function pointer with `offset` field
 - default to disabled color inversion for all generic models
 - renamed `Display::set_scroll_region` and `Display::set_scroll_offset` into `set_vertical_scroll_region` and `set_vertical_scroll_offset`
+- removed `Model::default_options`
 
 ### Removed
 

--- a/mipidsi/src/builder.rs
+++ b/mipidsi/src/builder.rs
@@ -50,7 +50,7 @@ where
         Self {
             di,
             model,
-            options: MODEL::default_options(),
+            options: ModelOptions::full_size::<MODEL>(),
         }
     }
 

--- a/mipidsi/src/models.rs
+++ b/mipidsi/src/models.rs
@@ -72,10 +72,4 @@ pub trait Model {
     where
         DI: WriteOnlyDataCommand,
         I: IntoIterator<Item = Self::ColorFormat>;
-
-    /// Creates default [ModelOptions] for this particular [Model].
-    ///
-    /// This serves as a "sane default". There can be additional variants which will be provided via
-    /// helper constructors.
-    fn default_options() -> ModelOptions;
 }

--- a/mipidsi/src/models/gc9a01.rs
+++ b/mipidsi/src/models/gc9a01.rs
@@ -144,10 +144,6 @@ impl Model for GC9A01 {
         dcs.di.send_data(buf)?;
         Ok(())
     }
-
-    fn default_options() -> ModelOptions {
-        ModelOptions::full_size::<Self>()
-    }
 }
 
 // simplified constructor on Display

--- a/mipidsi/src/models/ili9341.rs
+++ b/mipidsi/src/models/ili9341.rs
@@ -49,10 +49,6 @@ impl Model for ILI9341Rgb565 {
     {
         ili934x::write_pixels_rgb565(dcs, colors)
     }
-
-    fn default_options() -> ModelOptions {
-        ModelOptions::full_size::<Self>()
-    }
 }
 
 impl Model for ILI9341Rgb666 {
@@ -86,10 +82,6 @@ impl Model for ILI9341Rgb666 {
         I: IntoIterator<Item = Self::ColorFormat>,
     {
         ili934x::write_pixels_rgb666(dcs, colors)
-    }
-
-    fn default_options() -> ModelOptions {
-        ModelOptions::full_size::<Self>()
     }
 }
 

--- a/mipidsi/src/models/ili9342c.rs
+++ b/mipidsi/src/models/ili9342c.rs
@@ -49,10 +49,6 @@ impl Model for ILI9342CRgb565 {
     {
         ili934x::write_pixels_rgb565(dcs, colors)
     }
-
-    fn default_options() -> ModelOptions {
-        ModelOptions::full_size::<Self>()
-    }
 }
 
 impl Model for ILI9342CRgb666 {
@@ -86,10 +82,6 @@ impl Model for ILI9342CRgb666 {
         I: IntoIterator<Item = Self::ColorFormat>,
     {
         ili934x::write_pixels_rgb666(dcs, colors)
-    }
-
-    fn default_options() -> ModelOptions {
-        ModelOptions::full_size::<Self>()
     }
 }
 

--- a/mipidsi/src/models/ili9486.rs
+++ b/mipidsi/src/models/ili9486.rs
@@ -61,10 +61,6 @@ impl Model for ILI9486Rgb565 {
         let buf = DataFormat::U16BEIter(&mut iter);
         dcs.di.send_data(buf)
     }
-
-    fn default_options() -> ModelOptions {
-        ModelOptions::full_size::<Self>()
-    }
 }
 
 impl Model for ILI9486Rgb666 {
@@ -109,10 +105,6 @@ impl Model for ILI9486Rgb666 {
 
         let buf = DataFormat::U8Iter(&mut iter);
         dcs.di.send_data(buf)
-    }
-
-    fn default_options() -> ModelOptions {
-        ModelOptions::full_size::<Self>()
     }
 }
 

--- a/mipidsi/src/models/st7735s.rs
+++ b/mipidsi/src/models/st7735s.rs
@@ -92,10 +92,6 @@ impl Model for ST7735s {
         dcs.di.send_data(buf)?;
         Ok(())
     }
-
-    fn default_options() -> ModelOptions {
-        ModelOptions::full_size::<Self>()
-    }
 }
 
 // simplified constructor on Display

--- a/mipidsi/src/models/st7789.rs
+++ b/mipidsi/src/models/st7789.rs
@@ -80,8 +80,4 @@ impl Model for ST7789 {
         dcs.di.send_data(buf)?;
         Ok(())
     }
-
-    fn default_options() -> ModelOptions {
-        ModelOptions::full_size::<Self>()
-    }
 }


### PR DESCRIPTION
This PR removes the `default_options` method from the `Model` trait. It is no longer required after the color inversion was removed from some models to make the behaviour more consistent for different models.