### PR TITLE
Update CI config and build RP pico example in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,12 +7,12 @@ name: Continuous integration
 
 jobs:
   ci-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       matrix:
         # All generated code should be running on stable now, MRSV is 1.61.0
-        rust: [nightly, stable, 1.61.0]
+        rust: [nightly, stable, 1.75.0]
 
         include:
           # Nightly is only for reference and allowed to fail
@@ -20,14 +20,10 @@ jobs:
             experimental: true
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
-      - name: Install all Rust targets for ${{ matrix.rust }}
-        run: rustup target install --toolchain=${{ matrix.rust }} x86_64-unknown-linux-gnu
       - name: Run CI script for x86_64-unknown-linux-gnu
         run: |
           cargo check
@@ -45,15 +41,23 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - name: Build crate for host OS
         run: |
           cargo build
       - name: Test on host OS
         run: |
           cargo test
+
+  build-example-parallel-ili9341-rp-pico:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: thumbv6m-none-eabi
+      - run: cargo install flip-link
+      - name: Build example
+        run: cargo build
+        working-directory: ./mipidsi/examples/parallel_ili9341_rp_pico

--- a/mipidsi/examples/parallel_ili9341_rp_pico/Cargo.toml
+++ b/mipidsi/examples/parallel_ili9341_rp_pico/Cargo.toml
@@ -18,3 +18,5 @@ embedded-graphics = "0.8.0"
 embedded-graphics-core = "0.4.0"
 display-interface-parallel-gpio = "0.6.0"
 mipidsi = "0.7.1"
+
+[workspace]


### PR DESCRIPTION
This PR updates the CI config to get rid of some deprecation messages.

I've also started to add CI jobs to build the examples. While we cannot run the examples this at least makes sure they remain buildable. This PR only adds a job to build the PR pico example, the other examples can be added in future PRs.