### PR TITLE
Run all doctests

### DIFF
--- a/mipidsi/Cargo.toml
+++ b/mipidsi/Cargo.toml
@@ -21,6 +21,11 @@ nb = "1.0.0"
 optional = true
 version = "0.7.16"
 
+[dev-dependencies]
+embedded-graphics = "0.8.0"
+display-interface-spi = "0.5.0"
+display-interface-parallel-gpio = "0.7.0"
+
 [features]
 default = ["batch"]
 batch = ["heapless"]

--- a/mipidsi/src/builder.rs
+++ b/mipidsi/src/builder.rs
@@ -11,12 +11,17 @@ use crate::options::{ColorInversion, ColorOrder, ModelOptions, Orientation, Refr
 ///
 /// Exposes all possible display options.
 ///
+/// # Examples
 ///
-/// ## Example
-/// ```rust ignore
+/// ```
+/// use mipidsi::{Builder, options::ColorOrder};
+///
+/// # let di = mipidsi::_mock::MockDisplayInterface;
+/// # let rst = mipidsi::_mock::MockOutputPin;
+/// # let mut delay = mipidsi::_mock::MockDelay;
 /// let mut display = Builder::ili9342c_rgb565(di)
-///     .with_color_order(ColorOrder::Bgr);
-///     .with_display_size(320, 240);
+///     .with_color_order(ColorOrder::Bgr)
+///     .with_display_size(320, 240)
 ///     .init(&mut delay, Some(rst)).unwrap();
 /// ```
 pub struct Builder<DI, MODEL>


### PR DESCRIPTION
This PR adds mock (noop) implementations of some embedded-hal and display-interface traits to make it possible to compile all our doctests. The tests could still use some work, but this PR is only intended to add to necessary infrastructure to remove the ignore flag from all doctests. These changes should make it easier to keep the examples up to date in the future and prevent typos that brake the code (like in the `Builder` example).

Unfortunately there is no great way to conditionally add code for doctests and the only solution I could come up with is a hidden `_mock` module in the create root.