### PR TITLE
Remove reset pin parameter from Builder::init

### DIFF
--- a/mipidsi/CHANGELOG.md
+++ b/mipidsi/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - bumped MSRV to `v1.75`
 - fixed `DrawTarget::fill_contiguous` for images that overlap the edge of the framebuffer
 - replaced model specific `Builder` constructors (like `Builder::gc9a01`) with one generic `Builder::new` constructor
+- replaced rest pin parameter in `Builder::init` by `Builder::with_reset_pin` setter
 
 ### Removed
 

--- a/mipidsi/docs/MIGRATION.md
+++ b/mipidsi/docs/MIGRATION.md
@@ -8,11 +8,21 @@
   ```rust
   // 0.7
   use mipidsi::Builder;
+  let display = Builder::ili9341_rgb565(di).init(&mut delay, None)?;
+
+  // 0.8
+  use mipidsi::{Builder, models::ILI9341Rgb565};
+  let display = Builder::new(ILI9341Rgb565, di).init(&mut delay)?;
+  ```
+* The reset pin parameter from `Builder::init` has been removed. Use the `Builder::with_reset_pin` setter instead:
+  ```rust
+  // 0.7
+  use mipidsi::Builder;
   let display = Builder::ili9341_rgb565(di).init(&mut delay, Some(rst))?;
 
   // 0.8
   use mipidsi::{Builder, models::ILI9341Rgb565};
-  let display = Builder::new(ILI9341Rgb565, di).init(&mut delay, Some(rst))?;
+  let display = Builder::new(ILI9341Rgb565, di).with_reset_pin(rst).init(&mut delay)?;
   ```
 
 ## v0.6 -> 0.7

--- a/mipidsi/src/builder.rs
+++ b/mipidsi/src/builder.rs
@@ -1,6 +1,7 @@
 //! [super::Display] builder module
 
 use display_interface::WriteOnlyDataCommand;
+use embedded_hal::digital;
 use embedded_hal::{delay::DelayNs, digital::OutputPin};
 
 use crate::{dcs::Dcs, error::InitError, models::Model, Display};
@@ -20,21 +21,23 @@ use crate::options::{ColorInversion, ColorOrder, ModelOptions, Orientation, Refr
 /// # let rst = mipidsi::_mock::MockOutputPin;
 /// # let mut delay = mipidsi::_mock::MockDelay;
 /// let mut display = Builder::new(ILI9342CRgb565, di)
+///     .with_reset_pin(rst)
 ///     .with_color_order(ColorOrder::Bgr)
 ///     .with_display_size(320, 240)
-///     .init(&mut delay, Some(rst)).unwrap();
+///     .init(&mut delay).unwrap();
 /// ```
-pub struct Builder<DI, MODEL>
+pub struct Builder<DI, MODEL, RST>
 where
     DI: WriteOnlyDataCommand,
     MODEL: Model,
 {
     di: DI,
     model: MODEL,
+    rst: Option<RST>,
     options: ModelOptions,
 }
 
-impl<DI, MODEL> Builder<DI, MODEL>
+impl<DI, MODEL> Builder<DI, MODEL, NoResetPin>
 where
     DI: WriteOnlyDataCommand,
     MODEL: Model,
@@ -46,10 +49,18 @@ where
         Self {
             di,
             model,
+            rst: None,
             options: ModelOptions::full_size::<MODEL>(),
         }
     }
+}
 
+impl<DI, MODEL, RST> Builder<DI, MODEL, RST>
+where
+    DI: WriteOnlyDataCommand,
+    MODEL: Model,
+    RST: OutputPin,
+{
     ///
     /// Sets the invert color flag
     ///
@@ -98,6 +109,16 @@ where
         self
     }
 
+    /// Sets the reset pin.
+    pub fn with_reset_pin<RST2: OutputPin>(self, rst: RST2) -> Builder<DI, MODEL, RST2> {
+        Builder {
+            di: self.di,
+            model: self.model,
+            rst: Some(rst),
+            options: self.options,
+        }
+    }
+
     ///
     /// Consumes the builder to create a new [Display] with an optional reset [OutputPin].
     /// Blocks using the provided [DelayUs] `delay_source` to perform the display initialization.
@@ -106,27 +127,66 @@ where
     /// ### WARNING
     /// The reset pin needs to be in *high* state in order for the display to operate.
     /// If it wasn't provided the user needs to ensure this is the case.
-    pub fn init<RST>(
+    pub fn init(
         mut self,
         delay_source: &mut impl DelayNs,
-        mut rst: Option<RST>,
-    ) -> Result<Display<DI, MODEL, RST>, InitError<RST::Error>>
-    where
-        RST: OutputPin,
-    {
+    ) -> Result<Display<DI, MODEL, RST>, InitError<RST::Error>> {
         let mut dcs = Dcs::write_only(self.di);
         let madctl = self
             .model
-            .init(&mut dcs, delay_source, &self.options, &mut rst)?;
+            .init(&mut dcs, delay_source, &self.options, &mut self.rst)?;
+
         let display = Display {
             dcs,
             model: self.model,
-            rst,
+            rst: self.rst,
             options: self.options,
             madctl,
             sleeping: false, // TODO: init should lock state
         };
 
         Ok(display)
+    }
+}
+
+/// Marker type for no reset pin.
+pub enum NoResetPin {}
+
+impl digital::OutputPin for NoResetPin {
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl digital::ErrorType for NoResetPin {
+    type Error = core::convert::Infallible;
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        _mock::{MockDelay, MockDisplayInterface, MockOutputPin},
+        models::ILI9341Rgb565,
+    };
+
+    use super::*;
+
+    #[test]
+    fn init_without_reset_pin() {
+        let _: Display<_, _, NoResetPin> = Builder::new(ILI9341Rgb565, MockDisplayInterface)
+            .init(&mut MockDelay)
+            .unwrap();
+    }
+
+    #[test]
+    fn init_with_reset_pin() {
+        let _: Display<_, _, MockOutputPin> = Builder::new(ILI9341Rgb565, MockDisplayInterface)
+            .with_reset_pin(MockOutputPin)
+            .init(&mut MockDelay)
+            .unwrap();
     }
 }

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -38,7 +38,8 @@
 //!
 //! // Create the ILI9486 display driver from the display interface and optional RST pin
 //! let mut display = Builder::new(ILI9486Rgb666, di)
-//!     .init(&mut delay, Some(rst)).unwrap();
+//!     .with_reset_pin(rst)
+//!     .init(&mut delay).unwrap();
 //!
 //! // Clear the display to black
 //! display.clear(Rgb666::BLACK).unwrap();
@@ -78,13 +79,14 @@
 //!
 //! // Create the ILI9341 display driver from the display interface with the RGB666 color space
 //! let mut display = Builder::new(ILI9341Rgb666, di)
+//!      .with_reset_pin(rst)
 //!      .with_color_order(mipidsi::options::ColorOrder::Bgr)
-//!      .init(&mut delay, Some(rst)).unwrap();
+//!      .init(&mut delay).unwrap();
 //!
 //! // Clear the display to black
 //! display.clear(Rgb666::RED).unwrap();
 //! ```
-//! Use the appropiate display interface crate for your needs:
+//! Use the appropriate display interface crate for your needs:
 //! - [`display-interface-spi`](https://docs.rs/display-interface-spi/)
 //! - [`display-interface-parallel-gpio`](https://docs.rs/display-interface-parallel-gpio)
 //! - [`display-interface-i2c`](https://docs.rs/display-interface-i2c/)
@@ -105,7 +107,7 @@ pub mod options;
 use options::MemoryMapping;
 
 mod builder;
-pub use builder::Builder;
+pub use builder::{Builder, NoResetPin};
 
 pub mod dcs;
 
@@ -373,11 +375,11 @@ pub mod _mock {
     use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
     use embedded_hal::{delay::DelayNs, digital, spi};
 
-    use crate::{models::ILI9341Rgb565, Builder, Display};
+    use crate::{models::ILI9341Rgb565, Builder, Display, NoResetPin};
 
-    pub fn new_mock_display() -> Display<MockDisplayInterface, ILI9341Rgb565, MockOutputPin> {
+    pub fn new_mock_display() -> Display<MockDisplayInterface, ILI9341Rgb565, NoResetPin> {
         Builder::new(ILI9341Rgb565, MockDisplayInterface)
-            .init(&mut MockDelay, Some(MockOutputPin))
+            .init(&mut MockDelay)
             .unwrap()
     }
 


### PR DESCRIPTION
This PR removes the reset parameter from `Builder::init` and replaces it with a setter. The setter is a bit easier to use, because the argument doesn't need to be wrapped into an `Option`. I think it's also advantageous to not have `init` take one argument which is only borrowed (the delay) and another that remains owned by the `Builder`/`Display` (the reset pin).