### PR TITLE
added ST7796 model

### DIFF
--- a/mipidsi/CHANGELOG.md
+++ b/mipidsi/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - added `Display::is_sleeping` method
 - added `Display::dcs` method to allow sending custom DCS commands to the device
 - added `TestImage::default`
+- added `ST7796` model support (#125)
 
 ### Changed
 

--- a/mipidsi/README.md
+++ b/mipidsi/README.md
@@ -41,6 +41,7 @@ Variants that require different screen sizes and window addressing offsets are n
 * ILI9486
 * ST7735
 * ST7789
+* ST7796
 
 ## Migration
 

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -12,11 +12,13 @@
 //!
 //! ### List of supported models
 //!
-//! * ST7789
-//! * ST7735
-//! * ILI9486
+//! * GC9A01
 //! * ILI9341
 //! * ILI9342C
+//! * ILI9486
+//! * ST7735
+//! * ST7789
+//! * ST7796
 //!
 //! ## Examples
 //! **For the ili9486 display, using the SPI interface with no chip select:**

--- a/mipidsi/src/models.rs
+++ b/mipidsi/src/models.rs
@@ -18,6 +18,7 @@ mod ili934x;
 mod ili9486;
 mod st7735s;
 mod st7789;
+mod st7796;
 
 pub use gc9a01::*;
 pub use ili9341::*;
@@ -25,6 +26,7 @@ pub use ili9342c::*;
 pub use ili9486::*;
 pub use st7735s::*;
 pub use st7789::*;
+pub use st7796::*;
 
 /// Display model.
 pub trait Model {

--- a/mipidsi/src/models/st7796.rs
+++ b/mipidsi/src/models/st7796.rs
@@ -1,0 +1,78 @@
+use display_interface::{DataFormat, WriteOnlyDataCommand};
+use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
+use embedded_hal::{delay::DelayNs, digital::OutputPin};
+
+use crate::{
+    dcs::{
+        BitsPerPixel, Dcs, EnterNormalMode, ExitSleepMode, PixelFormat, SetAddressMode,
+        SetDisplayOn, SetInvertMode, SetPixelFormat, SoftReset, WriteMemoryStart,
+    },
+    error::{Error, InitError},
+    models::Model,
+    options::ModelOptions,
+};
+
+/// ST7796 display in Rgb565 color mode.
+///
+/// Interfaces implemented by the [display-interface](https://crates.io/crates/display-interface) are supported.
+pub struct ST7796;
+
+impl Model for ST7796 {
+    type ColorFormat = Rgb565;
+    const FRAMEBUFFER_SIZE: (u16, u16) = (320, 480);
+
+    fn init<RST, DELAY, DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+        rst: &mut Option<RST>,
+    ) -> Result<SetAddressMode, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayNs,
+        DI: WriteOnlyDataCommand,
+    {
+        let madctl = SetAddressMode::from(options);
+
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay)?,
+            None => dcs.write_command(SoftReset)?,
+        }
+        delay.delay_us(150_000);
+
+        dcs.write_command(ExitSleepMode)?;
+        delay.delay_us(10_000);
+
+        // set hw scroll area based on framebuffer size
+        dcs.write_command(madctl)?;
+
+        dcs.write_command(SetInvertMode::new(options.invert_colors))?;
+
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+        dcs.write_command(SetPixelFormat::new(pf))?;
+        delay.delay_us(10_000);
+        dcs.write_command(EnterNormalMode)?;
+        delay.delay_us(10_000);
+        dcs.write_command(SetDisplayOn)?;
+
+        // DISPON requires some time otherwise we risk SPI data issues
+        delay.delay_us(120_000);
+
+        Ok(madctl)
+    }
+
+    fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+    where
+        DI: WriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        dcs.write_command(WriteMemoryStart)?;
+
+        let mut iter = colors.into_iter().map(Rgb565::into_storage);
+
+        let buf = DataFormat::U16BEIter(&mut iter);
+        dcs.di.send_data(buf)?;
+        Ok(())
+    }
+}

--- a/mipidsi/src/models/st7796.rs
+++ b/mipidsi/src/models/st7796.rs
@@ -1,12 +1,9 @@
-use display_interface::{DataFormat, WriteOnlyDataCommand};
-use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
+use display_interface::WriteOnlyDataCommand;
+use embedded_graphics_core::pixelcolor::Rgb565;
 use embedded_hal::{delay::DelayNs, digital::OutputPin};
 
 use crate::{
-    dcs::{
-        BitsPerPixel, Dcs, EnterNormalMode, ExitSleepMode, PixelFormat, SetAddressMode,
-        SetDisplayOn, SetInvertMode, SetPixelFormat, SoftReset, WriteMemoryStart,
-    },
+    dcs::{Dcs, SetAddressMode},
     error::{Error, InitError},
     models::Model,
     options::ModelOptions,
@@ -33,33 +30,7 @@ impl Model for ST7796 {
         DELAY: DelayNs,
         DI: WriteOnlyDataCommand,
     {
-        let madctl = SetAddressMode::from(options);
-
-        match rst {
-            Some(ref mut rst) => self.hard_reset(rst, delay)?,
-            None => dcs.write_command(SoftReset)?,
-        }
-        delay.delay_us(150_000);
-
-        dcs.write_command(ExitSleepMode)?;
-        delay.delay_us(10_000);
-
-        // set hw scroll area based on framebuffer size
-        dcs.write_command(madctl)?;
-
-        dcs.write_command(SetInvertMode::new(options.invert_colors))?;
-
-        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
-        dcs.write_command(SetPixelFormat::new(pf))?;
-        delay.delay_us(10_000);
-        dcs.write_command(EnterNormalMode)?;
-        delay.delay_us(10_000);
-        dcs.write_command(SetDisplayOn)?;
-
-        // DISPON requires some time otherwise we risk SPI data issues
-        delay.delay_us(120_000);
-
-        Ok(madctl)
+        super::ST7789.init(dcs, delay, options, rst)
     }
 
     fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
@@ -67,12 +38,6 @@ impl Model for ST7796 {
         DI: WriteOnlyDataCommand,
         I: IntoIterator<Item = Self::ColorFormat>,
     {
-        dcs.write_command(WriteMemoryStart)?;
-
-        let mut iter = colors.into_iter().map(Rgb565::into_storage);
-
-        let buf = DataFormat::U16BEIter(&mut iter);
-        dcs.di.send_data(buf)?;
-        Ok(())
+        super::ST7789.write_pixels(dcs, colors)
     }
 }


### PR DESCRIPTION
Added a model for ST7796.

Previously I used the ST7789 model and set the framebuffer size via options, since thats not possible now, I created a model for it.  Its exactly ST7789 but with the framebuffer size changed.
