### PR TITLE
Make ModelOptions fields public

### DIFF
--- a/mipidsi/CHANGELOG.md
+++ b/mipidsi/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - fixed `DrawTarget::fill_contiguous` for images that overlap the edge of the framebuffer
 - replaced model specific `Builder` constructors (like `Builder::gc9a01`) with one generic `Builder::new` constructor
 - replaced rest pin parameter in `Builder::init` by `Builder::with_reset_pin` setter
+- removed setters and getters from `ModelOptions` and instead made the fields public
+- added `non_exhaustive` attribute to `ModelOptions`
 
 ### Removed
 

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -155,7 +155,7 @@ where
     /// Returns currently set [options::Orientation]
     ///
     pub fn orientation(&self) -> options::Orientation {
-        self.options.orientation()
+        self.options.orientation
     }
 
     ///

--- a/mipidsi/src/options.rs
+++ b/mipidsi/src/options.rs
@@ -6,23 +6,23 @@ mod orientation;
 pub(crate) use orientation::MemoryMapping;
 pub use orientation::{InvalidAngleError, Orientation, Rotation};
 
-/// [ModelOptions] holds the settings for [Model]s.
-///
-/// `display_size` being set is the minimum requirement.
+/// [ModelOptions] are passed to the [`init`](Model::init) method of [Model]
+/// implementations.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct ModelOptions {
-    /// Specify display color ordering
-    pub(crate) color_order: ColorOrder,
-    /// Initial display orientation (without inverts)
-    pub(crate) orientation: Orientation,
+    /// Subpixel order.
+    pub color_order: ColorOrder,
+    /// Initial display orientation.
+    pub orientation: Orientation,
     /// Whether to invert colors for this display/model (INVON)
-    pub(crate) invert_colors: ColorInversion,
-    /// Display refresh order
-    pub(crate) refresh_order: RefreshOrder,
-    /// Display size (w, h) for given display/model
-    pub(crate) display_size: (u16, u16),
-    /// Display offset (x, y) for given display/model
-    pub(crate) display_offset: (u16, u16),
+    pub invert_colors: ColorInversion,
+    /// Display refresh order.
+    pub refresh_order: RefreshOrder,
+    /// Display size (w, h) for given display.
+    pub display_size: (u16, u16),
+    /// Display offset (x, y) for given display.
+    pub display_offset: (u16, u16),
 }
 
 impl ModelOptions {
@@ -50,11 +50,6 @@ impl ModelOptions {
         }
     }
 
-    /// Sets the color inversion setting.
-    pub fn set_invert_colors(&mut self, color_inversion: ColorInversion) {
-        self.invert_colors = color_inversion;
-    }
-
     /// Returns the display size based on current orientation and display options.
     ///
     /// Used by models.
@@ -64,16 +59,6 @@ impl ModelOptions {
         } else {
             (self.display_size.1, self.display_size.0)
         }
-    }
-
-    /// Returns the current orientation.
-    pub fn orientation(&self) -> Orientation {
-        self.orientation
-    }
-
-    /// Sets the orientation.
-    pub fn set_orientation(&mut self, orientation: Orientation) {
-        self.orientation = orientation;
     }
 }
 

--- a/mipidsi/tests/external.rs
+++ b/mipidsi/tests/external.rs
@@ -1,0 +1,76 @@
+use display_interface::{DataFormat, WriteOnlyDataCommand};
+use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
+use embedded_hal::{delay::DelayNs, digital::OutputPin};
+use mipidsi::{
+    dcs::{
+        BitsPerPixel, Dcs, EnterNormalMode, ExitSleepMode, PixelFormat, SetAddressMode,
+        SetDisplayOn, SetInvertMode, SetPixelFormat, SoftReset, WriteMemoryStart,
+    },
+    error::{Error, InitError},
+    models::Model,
+    options::ModelOptions,
+};
+
+/// Copy of the ST7789 driver to check if it can also be implemented in another
+/// crate.
+pub struct ExternalST7789;
+
+impl Model for ExternalST7789 {
+    type ColorFormat = Rgb565;
+    const FRAMEBUFFER_SIZE: (u16, u16) = (240, 320);
+
+    fn init<RST, DELAY, DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+        rst: &mut Option<RST>,
+    ) -> Result<SetAddressMode, InitError<RST::Error>>
+    where
+        RST: OutputPin,
+        DELAY: DelayNs,
+        DI: WriteOnlyDataCommand,
+    {
+        let madctl = SetAddressMode::from(options);
+
+        match rst {
+            Some(ref mut rst) => self.hard_reset(rst, delay)?,
+            None => dcs.write_command(SoftReset)?,
+        }
+        delay.delay_us(150_000);
+
+        dcs.write_command(ExitSleepMode)?;
+        delay.delay_us(10_000);
+
+        // set hw scroll area based on framebuffer size
+        dcs.write_command(madctl)?;
+
+        dcs.write_command(SetInvertMode::new(options.invert_colors))?;
+
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+        dcs.write_command(SetPixelFormat::new(pf))?;
+        delay.delay_us(10_000);
+        dcs.write_command(EnterNormalMode)?;
+        delay.delay_us(10_000);
+        dcs.write_command(SetDisplayOn)?;
+
+        // DISPON requires some time otherwise we risk SPI data issues
+        delay.delay_us(120_000);
+
+        Ok(madctl)
+    }
+
+    fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+    where
+        DI: WriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        dcs.write_command(WriteMemoryStart)?;
+
+        let mut iter = colors.into_iter().map(Rgb565::into_storage);
+
+        let buf = DataFormat::U16BEIter(&mut iter);
+        dcs.di.send_data(buf)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR makes the fields in `ModelOptions` public. It isn't possible to access the model options mutably from user code or external `Model` impls, which makes setters/getters unnecessary. I've also added a test to check that it is possible to implement external models and ensure that we don't remove this possibility accidentally in the future.

Fixes #126. 