### PR TITLE
Use path dependencies for examples

### DIFF
--- a/mipidsi/examples/parallel_ili9341_rp_pico/Cargo.toml
+++ b/mipidsi/examples/parallel_ili9341_rp_pico/Cargo.toml
@@ -4,19 +4,19 @@ name = "parallel_ili9341_rp_pico"
 version = "0.1.0"
 
 [dependencies]
-cortex-m = "0.7"
-cortex-m-rt = "0.7"
-embedded-hal = { version = "0.2.5", features = ["unproven"] }
+cortex-m = "0.7.7"
+cortex-m-rt = "0.7.4"
+embedded-hal = "1.0.0"
 
-defmt = "0.3"
+defmt = "0.3.6"
 defmt-rtt = "0.4"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 
-rp-pico = "0.7"
+rp-pico = "0.9.0"
 
 embedded-graphics = "0.8.0"
 embedded-graphics-core = "0.4.0"
-display-interface-parallel-gpio = "0.6.0"
-mipidsi = "0.7.1"
+display-interface-parallel-gpio = "0.7.0"
+mipidsi = { path = "../../" }
 
 [workspace]

--- a/mipidsi/examples/spi-ili9486-esp32-c3/.cargo/config.toml
+++ b/mipidsi/examples/spi-ili9486-esp32-c3/.cargo/config.toml
@@ -7,22 +7,6 @@ rustflags = [
   # Required to obtain backtraces (e.g. when using the "esp-backtrace" crate.)
   # NOTE: May negatively impact performance of produced code
   "-C", "force-frame-pointers",
-
-  # comment the cfgs below if you do _not_ wish to emulate atomics.
-  # enable the atomic codegen option for RISCV
-  "-C", "target-feature=+a",
-  # tell the core library have atomics even though it's not specified in the target definition
-  "--cfg", "target_has_atomic_load_store",
-  "--cfg", 'target_has_atomic_load_store="8"',
-  "--cfg", 'target_has_atomic_load_store="16"',
-  "--cfg", 'target_has_atomic_load_store="32"',
-  "--cfg", 'target_has_atomic_load_store="ptr"',
-  # enable cas
-  "--cfg", "target_has_atomic",
-  "--cfg", 'target_has_atomic="8"',
-  "--cfg", 'target_has_atomic="16"',
-  "--cfg", 'target_has_atomic="32"',
-  "--cfg", 'target_has_atomic="ptr"',
 ]
 
 target = "riscv32imc-unknown-none-elf"

--- a/mipidsi/examples/spi-ili9486-esp32-c3/Cargo.toml
+++ b/mipidsi/examples/spi-ili9486-esp32-c3/Cargo.toml
@@ -4,12 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-hal = { package = "esp32c3-hal", version = "0.10.0" }
-esp-backtrace = { version = "0.7.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
-esp-println       = { version = "0.5.0", features = ["esp32c3"] }
+mipidsi = { path = "../../" }
+hal = { package = "esp-hal", version = "0.17.0", features = ["esp32c3"] }
+esp-backtrace = { version = "0.11.1", features = ["esp32c3", "panic-handler", "exception-handler", "println"] }
+esp-println = { version = "0.9.1", features = ["esp32c3"] }
 embedded-graphics = "0.8.0"
-display-interface-spi = "0.4.1"
-mipidsi = "0.7.1"
+display-interface-spi = "0.5.0"
 fugit = "0.3.7"
+embedded-hal-bus = "0.2.0"
 
 [workspace]

--- a/mipidsi/examples/spi-st7789-rpi-zero-w/Cargo.toml
+++ b/mipidsi/examples/spi-st7789-rpi-zero-w/Cargo.toml
@@ -4,9 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-display-interface-spi = "0.4.1"
+mipidsi = { path = "../../" }
+display-interface-spi = "0.5.0"
 embedded-graphics = "0.8.0"
-mipidsi = "0.7.1"
-rppal = { version = "0.14.1", features = ["hal"] }
+rppal = { version = "0.17.1", features = ["hal"] }
+embedded-hal-bus = "0.2.0"
+embedded-hal = "1.0.0"
 
 [workspace]


### PR DESCRIPTION
This PR changes the dependencies in the examples to use a path dependency to make sure the examples stay compatible with the latest development version of `mipidsi`. I did not test any of the changes on real hardware yet, but at they should at least all compile.