### PR TITLE
Add checks for display size and offset

### DIFF
--- a/mipidsi/CHANGELOG.md
+++ b/mipidsi/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - replaced rest pin parameter in `Builder::init` by `Builder::with_reset_pin` setter
 - removed setters and getters from `ModelOptions` and instead made the fields public
 - added `non_exhaustive` attribute to `ModelOptions`
+- added checks to `Builder::init` to ensure that the display size and display offset are valid
 
 ### Removed
 


### PR DESCRIPTION
This PR adds checks to `init` to make sure that the display size and offset are valid. I've used panics instead of adding a new `InitError` variant, because the check would only fail if the program contains a bug and the other `InitError`s are runtime errors.