### PR TITLE
Add direct pixel writes from u8 buffers

### DIFF
--- a/mipidsi/CHANGELOG.md
+++ b/mipidsi/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- added `Display::set_pixels_from_buffer` to allow high performance display writes
+
 ## [v0.8.0] - 2024-05-24
 
 ### Added

--- a/mipidsi/examples/spi-ili9486-esp32-c3/Cargo.toml
+++ b/mipidsi/examples/spi-ili9486-esp32-c3/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 [dependencies]
 mipidsi = { path = "../../" }
 hal = { package = "esp-hal", version = "0.17.0", features = ["esp32c3"] }
-esp-backtrace = { version = "0.11.1", features = ["esp32c3", "panic-handler", "exception-handler", "println"] }
-esp-println = { version = "0.9.1", features = ["esp32c3"] }
+esp-backtrace = { version = "0.14", features = ["esp32c3", "panic-handler", "exception-handler", "println"] }
+esp-println = { version = "0.12", features = ["esp32c3"] }
 embedded-graphics = "0.8.0"
 display-interface-spi = "0.5.0"
 fugit = "0.3.7"

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -222,6 +222,10 @@ where
     /// * `ex` - x coordinate end
     /// * `ey` - y coordinate end
     /// * `colors` - anything that can provide `IntoIterator<Item = u16>` to iterate over pixel data
+    /// <div class="warning">
+    /// The `ex`and `ey` coordinates are inclusive. For example when using a rectangle
+    /// of size `320x240`, one would use `319` an `239` as `ex` and `ey` values.
+    /// </div>
     pub fn set_pixels<T>(
         &mut self,
         sx: u16,
@@ -255,7 +259,19 @@ where
     /// * `sy` - y coordinate start
     /// * `ex` - x coordinate end
     /// * `ey` - y coordinate end
-    /// * `raw_buf` - &[u8] buffer of raw pixel data in the format expected by the display.
+    /// * `raw_buf` - `&[u8]` buffer of raw pixel data in the format expected by the display.
+    /// <div class="warning">
+    /// This method requires the <b>raw_buf</b> data to be in the correct endianness
+    /// and format expected by the display.
+    ///
+    /// The method won't <b>work with a 16bit display-interface-gpio</b>, because it
+    /// pads the each byte to a u16 instead of converting each two byte chunk
+    /// into a u16. [See here for more info](https://github.com/therealprof/display-interface/blob/8fca041b0288740678f16c1d05cce21bd3867ee5/parallel-gpio/src/lib.rs#L267)
+    /// </div>
+    /// <div class="warning">
+    /// The <b>ex</b> and <b>ey</b> coordinates are inclusive. For example when using a rectangle
+    /// of size <b>320x240</b>, one would use <b>319</b> an <b>239</b> as <b>ex</b> and <b>ey</b> values.
+    /// </div>
     pub fn set_pixels_raw_u8(
         &mut self,
         sx: u16,

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -248,8 +248,6 @@ where
     /// slice has more color values than the number of pixels in the given region.
     ///
     /// This is a low level function, which isn't intended to be used in regular user code.
-    /// Consider using the [`draw_image`](https://TODO)
-    /// function from the `embedded-graphics` crate as an alternative instead (TODO)
     ///
     /// # Arguments
     ///

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -239,6 +239,39 @@ where
         Ok(())
     }
 
+    ///
+    /// Sets pixel colors in a rectangular region.
+    ///
+    /// The color values from the `raw_buf` slice will be drawn to the given region starting
+    /// at the top left corner and continuing, row first, to the bottom right corner. No bounds
+    /// checking is performed on the `raw_buf` slice and drawing will wrap around if the
+    /// slice has more color values than the number of pixels in the given region.
+    ///
+    /// This is a low level function, which isn't intended to be used in regular user code.
+    /// Consider using the [`draw_image`](https://TODO)
+    /// function from the `embedded-graphics` crate as an alternative instead (TODO)
+    ///
+    /// # Arguments
+    ///
+    /// * `sx` - x coordinate start
+    /// * `sy` - y coordinate start
+    /// * `ex` - x coordinate end
+    /// * `ey` - y coordinate end
+    /// * `raw_buf` - &[u8] buffer of raw pixel data in the format expected by the display.
+    pub fn set_pixels_raw_u8(
+        &mut self,
+        sx: u16,
+        sy: u16,
+        ex: u16,
+        ey: u16,
+        raw_buf: &[u8],
+    ) -> Result<(), Error> {
+        self.set_address_window(sx, sy, ex, ey)?;
+        self.model.write_pixels_raw_u8(&mut self.dcs, raw_buf)?;
+
+        Ok(())
+    }
+
     /// Sets the vertical scroll region.
     ///
     /// The `top_fixed_area` and `bottom_fixed_area` arguments can be used to

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -223,8 +223,12 @@ where
     /// * `ey` - y coordinate end
     /// * `colors` - anything that can provide `IntoIterator<Item = u16>` to iterate over pixel data
     /// <div class="warning">
-    /// The `ex`and `ey` coordinates are inclusive. For example when using a rectangle
-    /// of size `320x240`, one would use `319` an `239` as `ex` and `ey` values.
+    ///
+    /// The end values of the X and Y coordinate ranges are inclusive, and no
+    /// bounds checking is performed on these values. Using out of range values
+    /// (e.g., passing `320` instead of `319` for a 320 pixel wide display) will
+    /// result in undefined behavior.
+    ///
     /// </div>
     pub fn set_pixels<T>(
         &mut self,

--- a/mipidsi/src/models.rs
+++ b/mipidsi/src/models.rs
@@ -1,11 +1,11 @@
 //! Display models.
 
 use crate::{
-    dcs::{Dcs, SetAddressMode, WriteMemoryStart},
+    dcs::{Dcs, SetAddressMode},
     error::{Error, InitError},
     options::ModelOptions,
 };
-use display_interface::{DataFormat, WriteOnlyDataCommand};
+use display_interface::WriteOnlyDataCommand;
 use embedded_graphics_core::prelude::RgbColor;
 use embedded_hal::{delay::DelayNs, digital::OutputPin};
 
@@ -73,26 +73,4 @@ pub trait Model {
     where
         DI: WriteOnlyDataCommand,
         I: IntoIterator<Item = Self::ColorFormat>;
-
-    /// Writes raw `&[u8]` buffer to the display IC via the given display interface.
-    ///
-    /// No pixel color format conversion, raw data is passed on directly.
-    /// <div class="warning">
-    /// This method requires the `raw_buf` data to be in the correct endianness
-    /// and format expected by the display.
-    ///
-    /// The method <b>won't work with a 16bit display-interface-gpio</b>, because it
-    /// pads the each byte to a u16 instead of converting each two byte chunk
-    /// into a u16. [See here for more info](https://github.com/therealprof/display-interface/blob/8fca041b0288740678f16c1d05cce21bd3867ee5/parallel-gpio/src/lib.rs#L267)
-    /// </div>
-    fn write_pixels_raw_u8<DI>(&mut self, dcs: &mut Dcs<DI>, raw_buf: &[u8]) -> Result<(), Error>
-    where
-        DI: WriteOnlyDataCommand,
-    {
-        dcs.write_command(WriteMemoryStart)?;
-
-        let buf = DataFormat::U8(raw_buf);
-        dcs.di.send_data(buf)?;
-        Ok(())
-    }
 }

--- a/mipidsi/src/models.rs
+++ b/mipidsi/src/models.rs
@@ -1,12 +1,11 @@
 //! Display models.
 
 use crate::{
-    dcs::{Dcs, SetAddressMode},
-    error::Error,
-    error::InitError,
+    dcs::{Dcs, SetAddressMode, WriteMemoryStart},
+    error::{Error, InitError},
     options::ModelOptions,
 };
-use display_interface::WriteOnlyDataCommand;
+use display_interface::{DataFormat, WriteOnlyDataCommand};
 use embedded_graphics_core::prelude::RgbColor;
 use embedded_hal::{delay::DelayNs, digital::OutputPin};
 
@@ -74,4 +73,18 @@ pub trait Model {
     where
         DI: WriteOnlyDataCommand,
         I: IntoIterator<Item = Self::ColorFormat>;
+
+    /// Writes raw &[u8] buffer to the display IC via the given display interface.
+    ///
+    /// No pixel color format conversion, raw data is passed on directly.
+    fn write_pixels_raw_u8<DI>(&mut self, dcs: &mut Dcs<DI>, raw_buf: &[u8]) -> Result<(), Error>
+    where
+        DI: WriteOnlyDataCommand,
+    {
+        dcs.write_command(WriteMemoryStart)?;
+
+        let buf = DataFormat::U8(raw_buf);
+        dcs.di.send_data(buf)?;
+        Ok(())
+    }
 }

--- a/mipidsi/src/models.rs
+++ b/mipidsi/src/models.rs
@@ -74,9 +74,17 @@ pub trait Model {
         DI: WriteOnlyDataCommand,
         I: IntoIterator<Item = Self::ColorFormat>;
 
-    /// Writes raw &[u8] buffer to the display IC via the given display interface.
+    /// Writes raw `&[u8]` buffer to the display IC via the given display interface.
     ///
     /// No pixel color format conversion, raw data is passed on directly.
+    /// <div class="warning">
+    /// This method requires the `raw_buf` data to be in the correct endianness
+    /// and format expected by the display.
+    ///
+    /// The method <b>won't work with a 16bit display-interface-gpio</b>, because it
+    /// pads the each byte to a u16 instead of converting each two byte chunk
+    /// into a u16. [See here for more info](https://github.com/therealprof/display-interface/blob/8fca041b0288740678f16c1d05cce21bd3867ee5/parallel-gpio/src/lib.rs#L267)
+    /// </div>
     fn write_pixels_raw_u8<DI>(&mut self, dcs: &mut Dcs<DI>, raw_buf: &[u8]) -> Result<(), Error>
     where
         DI: WriteOnlyDataCommand,


### PR DESCRIPTION
Related to #142 this change will allow direct writes of `&[u8]` slice data via the `display-interface` without needing to do pixel format conversion in cases where the user knows it is safe to do so (e.g. prepared image data).

The hope is that this can get paired up with a change in `embedded-graphics` that enables such operations on a higher level (e.g. `draw_image`)