### PR TITLE
Fill solid optimizations per-color

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,5 +1,15 @@
 # Migration guide for `mipidsi` crate
 
+## v0.8 -> 0.9
+
+### Users
+
+* No changes
+
+### Model writers
+
+* `Model::repeat_pixel_to_buffer` requires implementation now. The easiest way to provide one is to use `mipidsi::graphics::repeat_pixel_to_buffer_rgbXXX` helpers.
+
 ## v0.7 -> 0.8
 
 ### Users

--- a/mipidsi/CHANGELOG.md
+++ b/mipidsi/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - added `Display::set_pixels_from_buffer` to allow high performance display writes
+- added `Model::repeat_pixel_to_buffer` and implementations to allow optimized path for `fill_solid` calls
 
 ## [v0.8.0] - 2024-05-24
 

--- a/mipidsi/src/graphics.rs
+++ b/mipidsi/src/graphics.rs
@@ -1,118 +1,18 @@
 use embedded_graphics_core::{
-    draw_target::DrawTarget,
-    geometry::{Dimensions, OriginDimensions, Size},
+    geometry::{OriginDimensions, Size},
     pixelcolor::RgbColor,
-    primitives::Rectangle,
-    Pixel,
 };
 use embedded_hal::digital::OutputPin;
 
 use crate::dcs::BitsPerPixel;
 use crate::models::Model;
-use crate::{error::Error, Display};
+use crate::Display;
 use display_interface::WriteOnlyDataCommand;
 
-impl<DI, M, RST> DrawTarget for Display<DI, M, RST>
-where
-    DI: WriteOnlyDataCommand,
-    M: Model,
-    RST: OutputPin,
-{
-    type Error = Error;
-    type Color = M::ColorFormat;
-
-    #[cfg(not(feature = "batch"))]
-    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
-    where
-        I: IntoIterator<Item = Pixel<Self::Color>>,
-    {
-        for pixel in pixels {
-            let x = pixel.0.x as u16;
-            let y = pixel.0.y as u16;
-
-            self.set_pixel(x, y, pixel.1)?;
-        }
-
-        Ok(())
-    }
-
-    #[cfg(feature = "batch")]
-    fn draw_iter<T>(&mut self, item: T) -> Result<(), Self::Error>
-    where
-        T: IntoIterator<Item = Pixel<Self::Color>>,
-    {
-        use crate::batch::DrawBatch;
-
-        self.draw_batch(item)
-    }
-
-    fn fill_contiguous<I>(&mut self, area: &Rectangle, colors: I) -> Result<(), Self::Error>
-    where
-        I: IntoIterator<Item = Self::Color>,
-    {
-        let intersection = area.intersection(&self.bounding_box());
-        let Some(bottom_right) = intersection.bottom_right() else {
-            // No intersection -> nothing to draw
-            return Ok(());
-        };
-
-        // Unchecked casting to u16 cannot fail here because the values are
-        // clamped to the display size which always fits in an u16.
-        let sx = intersection.top_left.x as u16;
-        let sy = intersection.top_left.y as u16;
-        let ex = bottom_right.x as u16;
-        let ey = bottom_right.y as u16;
-
-        let count = intersection.size.width * intersection.size.height;
-
-        let mut colors = colors.into_iter();
-
-        if &intersection == area {
-            // Draw the original iterator if no edge overlaps the framebuffer
-            self.set_pixels(sx, sy, ex, ey, take_u32(colors, count))
-        } else {
-            // Skip pixels above and to the left of the intersection
-            let mut initial_skip = 0;
-            if intersection.top_left.y > area.top_left.y {
-                initial_skip += intersection.top_left.y.abs_diff(area.top_left.y) * area.size.width;
-            }
-            if intersection.top_left.x > area.top_left.x {
-                initial_skip += intersection.top_left.x.abs_diff(area.top_left.x);
-            }
-            if initial_skip > 0 {
-                nth_u32(&mut colors, initial_skip - 1);
-            }
-
-            // Draw only the pixels which don't overlap the edges of the framebuffer
-            let take_per_row = intersection.size.width;
-            let skip_per_row = area.size.width - intersection.size.width;
-            self.set_pixels(
-                sx,
-                sy,
-                ex,
-                ey,
-                take_u32(TakeSkip::new(colors, take_per_row, skip_per_row), count),
-            )
-        }
-    }
-
-    fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
-        let area = area.intersection(&self.bounding_box());
-        let Some(bottom_right) = area.bottom_right() else {
-            // No intersection -> nothing to draw
-            return Ok(());
-        };
-
-        let count = area.size.width * area.size.height;
-        let mut colors = take_u32(core::iter::repeat(color), count);
-
-        let sx = area.top_left.x as u16;
-        let sy = area.top_left.y as u16;
-        let ex = bottom_right.x as u16;
-        let ey = bottom_right.y as u16;
-        self.set_pixels(sx, sy, ex, ey, &mut colors)
-    }
-}
+#[cfg(feature = "batch")]
+mod batch;
+#[cfg(not(feature = "batch"))]
+mod direct;
 
 impl<DI, MODEL, RST> OriginDimensions for Display<DI, MODEL, RST>
 where

--- a/mipidsi/src/graphics/batch.rs
+++ b/mipidsi/src/graphics/batch.rs
@@ -1,0 +1,111 @@
+use embedded_graphics_core::{
+    draw_target::DrawTarget, geometry::Dimensions, primitives::Rectangle, Pixel,
+};
+use embedded_hal::digital::OutputPin;
+
+use super::{nth_u32, take_u32, TakeSkip};
+use crate::models::Model;
+use crate::{error::Error, Display};
+use display_interface::WriteOnlyDataCommand;
+
+impl<DI, M, RST> DrawTarget for Display<DI, M, RST>
+where
+    DI: WriteOnlyDataCommand,
+    M: Model,
+    RST: OutputPin,
+{
+    type Error = Error;
+    type Color = M::ColorFormat;
+
+    #[cfg(not(feature = "batch"))]
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            let x = pixel.0.x as u16;
+            let y = pixel.0.y as u16;
+
+            self.set_pixel(x, y, pixel.1)?;
+        }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "batch")]
+    fn draw_iter<T>(&mut self, item: T) -> Result<(), Self::Error>
+    where
+        T: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        use crate::batch::DrawBatch;
+
+        self.draw_batch(item)
+    }
+
+    fn fill_contiguous<I>(&mut self, area: &Rectangle, colors: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Self::Color>,
+    {
+        let intersection = area.intersection(&self.bounding_box());
+        let Some(bottom_right) = intersection.bottom_right() else {
+            // No intersection -> nothing to draw
+            return Ok(());
+        };
+
+        // Unchecked casting to u16 cannot fail here because the values are
+        // clamped to the display size which always fits in an u16.
+        let sx = intersection.top_left.x as u16;
+        let sy = intersection.top_left.y as u16;
+        let ex = bottom_right.x as u16;
+        let ey = bottom_right.y as u16;
+
+        let count = intersection.size.width * intersection.size.height;
+
+        let mut colors = colors.into_iter();
+
+        if &intersection == area {
+            // Draw the original iterator if no edge overlaps the framebuffer
+            self.set_pixels(sx, sy, ex, ey, take_u32(colors, count))
+        } else {
+            // Skip pixels above and to the left of the intersection
+            let mut initial_skip = 0;
+            if intersection.top_left.y > area.top_left.y {
+                initial_skip += intersection.top_left.y.abs_diff(area.top_left.y) * area.size.width;
+            }
+            if intersection.top_left.x > area.top_left.x {
+                initial_skip += intersection.top_left.x.abs_diff(area.top_left.x);
+            }
+            if initial_skip > 0 {
+                nth_u32(&mut colors, initial_skip - 1);
+            }
+
+            // Draw only the pixels which don't overlap the edges of the framebuffer
+            let take_per_row = intersection.size.width;
+            let skip_per_row = area.size.width - intersection.size.width;
+            self.set_pixels(
+                sx,
+                sy,
+                ex,
+                ey,
+                take_u32(TakeSkip::new(colors, take_per_row, skip_per_row), count),
+            )
+        }
+    }
+
+    fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
+        let area = area.intersection(&self.bounding_box());
+        let Some(bottom_right) = area.bottom_right() else {
+            // No intersection -> nothing to draw
+            return Ok(());
+        };
+
+        let count = area.size.width * area.size.height;
+        let mut colors = take_u32(core::iter::repeat(color), count);
+
+        let sx = area.top_left.x as u16;
+        let sy = area.top_left.y as u16;
+        let ex = bottom_right.x as u16;
+        let ey = bottom_right.y as u16;
+        self.set_pixels(sx, sy, ex, ey, &mut colors)
+    }
+}

--- a/mipidsi/src/graphics/batch.rs
+++ b/mipidsi/src/graphics/batch.rs
@@ -35,12 +35,6 @@ where
             let mut raw_buf = [34u8; BUFFER_SIZE];
             let bytes_per_pixel = M::repeat_pixel_to_buffer(color, &mut raw_buf)?;
 
-            // model does not support this yet
-            if bytes_per_pixel == 0 {
-                let mut colors = super::take_u32(core::iter::repeat(color), ii.count);
-                return self.set_pixels(ii.sx, ii.sy, ii.ex, ii.ey, &mut colors);
-            }
-
             self.set_address_window(ii.sx, ii.sy, ii.ex, ii.ey)?;
 
             self.dcs.write_command(WriteMemoryStart)?;

--- a/mipidsi/src/graphics/batch.rs
+++ b/mipidsi/src/graphics/batch.rs
@@ -3,9 +3,8 @@ use embedded_graphics_core::{
 };
 use embedded_hal::digital::OutputPin;
 
-use super::{nth_u32, take_u32, TakeSkip};
-use crate::models::Model;
-use crate::{error::Error, Display};
+use super::take_u32;
+use crate::{batch::DrawBatch, error::Error, models::Model, Display};
 use display_interface::WriteOnlyDataCommand;
 
 impl<DI, M, RST> DrawTarget for Display<DI, M, RST>
@@ -17,28 +16,10 @@ where
     type Error = Error;
     type Color = M::ColorFormat;
 
-    #[cfg(not(feature = "batch"))]
-    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
-    where
-        I: IntoIterator<Item = Pixel<Self::Color>>,
-    {
-        for pixel in pixels {
-            let x = pixel.0.x as u16;
-            let y = pixel.0.y as u16;
-
-            self.set_pixel(x, y, pixel.1)?;
-        }
-
-        Ok(())
-    }
-
-    #[cfg(feature = "batch")]
     fn draw_iter<T>(&mut self, item: T) -> Result<(), Self::Error>
     where
         T: IntoIterator<Item = Pixel<Self::Color>>,
     {
-        use crate::batch::DrawBatch;
-
         self.draw_batch(item)
     }
 
@@ -46,66 +27,15 @@ where
     where
         I: IntoIterator<Item = Self::Color>,
     {
-        let intersection = area.intersection(&self.bounding_box());
-        let Some(bottom_right) = intersection.bottom_right() else {
-            // No intersection -> nothing to draw
-            return Ok(());
-        };
-
-        // Unchecked casting to u16 cannot fail here because the values are
-        // clamped to the display size which always fits in an u16.
-        let sx = intersection.top_left.x as u16;
-        let sy = intersection.top_left.y as u16;
-        let ex = bottom_right.x as u16;
-        let ey = bottom_right.y as u16;
-
-        let count = intersection.size.width * intersection.size.height;
-
-        let mut colors = colors.into_iter();
-
-        if &intersection == area {
-            // Draw the original iterator if no edge overlaps the framebuffer
-            self.set_pixels(sx, sy, ex, ey, take_u32(colors, count))
-        } else {
-            // Skip pixels above and to the left of the intersection
-            let mut initial_skip = 0;
-            if intersection.top_left.y > area.top_left.y {
-                initial_skip += intersection.top_left.y.abs_diff(area.top_left.y) * area.size.width;
-            }
-            if intersection.top_left.x > area.top_left.x {
-                initial_skip += intersection.top_left.x.abs_diff(area.top_left.x);
-            }
-            if initial_skip > 0 {
-                nth_u32(&mut colors, initial_skip - 1);
-            }
-
-            // Draw only the pixels which don't overlap the edges of the framebuffer
-            let take_per_row = intersection.size.width;
-            let skip_per_row = area.size.width - intersection.size.width;
-            self.set_pixels(
-                sx,
-                sy,
-                ex,
-                ey,
-                take_u32(TakeSkip::new(colors, take_per_row, skip_per_row), count),
-            )
-        }
+        super::fill_contiguous(self, area, colors)
     }
 
     fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
-        let area = area.intersection(&self.bounding_box());
-        let Some(bottom_right) = area.bottom_right() else {
-            // No intersection -> nothing to draw
-            return Ok(());
-        };
-
-        let count = area.size.width * area.size.height;
-        let mut colors = take_u32(core::iter::repeat(color), count);
-
-        let sx = area.top_left.x as u16;
-        let sy = area.top_left.y as u16;
-        let ex = bottom_right.x as u16;
-        let ey = bottom_right.y as u16;
-        self.set_pixels(sx, sy, ex, ey, &mut colors)
+        if let Some(ii) = super::calculate_intersection(area, &self.bounding_box())? {
+            let mut colors = take_u32(core::iter::repeat(color), ii.count);
+            self.set_pixels(ii.sx, ii.sy, ii.ex, ii.ey, &mut colors)
+        } else {
+            Ok(())
+        }
     }
 }

--- a/mipidsi/src/graphics/direct.rs
+++ b/mipidsi/src/graphics/direct.rs
@@ -39,6 +39,7 @@ where
 
     fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
         if let Some(ii) = super::calculate_intersection(area, &self.bounding_box())? {
+            // we don't have buffer allowance so we have to use an iterator here
             let mut colors = take_u32(core::iter::repeat(color), ii.count);
             self.set_pixels(ii.sx, ii.sy, ii.ex, ii.ey, &mut colors)
         } else {

--- a/mipidsi/src/graphics/direct.rs
+++ b/mipidsi/src/graphics/direct.rs
@@ -3,9 +3,8 @@ use embedded_graphics_core::{
 };
 use embedded_hal::digital::OutputPin;
 
-use super::{nth_u32, take_u32, TakeSkip};
-use crate::models::Model;
-use crate::{error::Error, Display};
+use super::take_u32;
+use crate::{error::Error, models::Model, Display};
 use display_interface::WriteOnlyDataCommand;
 
 impl<DI, M, RST> DrawTarget for Display<DI, M, RST>
@@ -35,66 +34,15 @@ where
     where
         I: IntoIterator<Item = Self::Color>,
     {
-        let intersection = area.intersection(&self.bounding_box());
-        let Some(bottom_right) = intersection.bottom_right() else {
-            // No intersection -> nothing to draw
-            return Ok(());
-        };
-
-        // Unchecked casting to u16 cannot fail here because the values are
-        // clamped to the display size which always fits in an u16.
-        let sx = intersection.top_left.x as u16;
-        let sy = intersection.top_left.y as u16;
-        let ex = bottom_right.x as u16;
-        let ey = bottom_right.y as u16;
-
-        let count = intersection.size.width * intersection.size.height;
-
-        let mut colors = colors.into_iter();
-
-        if &intersection == area {
-            // Draw the original iterator if no edge overlaps the framebuffer
-            self.set_pixels(sx, sy, ex, ey, take_u32(colors, count))
-        } else {
-            // Skip pixels above and to the left of the intersection
-            let mut initial_skip = 0;
-            if intersection.top_left.y > area.top_left.y {
-                initial_skip += intersection.top_left.y.abs_diff(area.top_left.y) * area.size.width;
-            }
-            if intersection.top_left.x > area.top_left.x {
-                initial_skip += intersection.top_left.x.abs_diff(area.top_left.x);
-            }
-            if initial_skip > 0 {
-                nth_u32(&mut colors, initial_skip - 1);
-            }
-
-            // Draw only the pixels which don't overlap the edges of the framebuffer
-            let take_per_row = intersection.size.width;
-            let skip_per_row = area.size.width - intersection.size.width;
-            self.set_pixels(
-                sx,
-                sy,
-                ex,
-                ey,
-                take_u32(TakeSkip::new(colors, take_per_row, skip_per_row), count),
-            )
-        }
+        super::fill_contiguous(self, area, colors)
     }
 
     fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
-        let area = area.intersection(&self.bounding_box());
-        let Some(bottom_right) = area.bottom_right() else {
-            // No intersection -> nothing to draw
-            return Ok(());
-        };
-
-        let count = area.size.width * area.size.height;
-        let mut colors = take_u32(core::iter::repeat(color), count);
-
-        let sx = area.top_left.x as u16;
-        let sy = area.top_left.y as u16;
-        let ex = bottom_right.x as u16;
-        let ey = bottom_right.y as u16;
-        self.set_pixels(sx, sy, ex, ey, &mut colors)
+        if let Some(ii) = super::calculate_intersection(area, &self.bounding_box())? {
+            let mut colors = take_u32(core::iter::repeat(color), ii.count);
+            self.set_pixels(ii.sx, ii.sy, ii.ex, ii.ey, &mut colors)
+        } else {
+            Ok(())
+        }
     }
 }

--- a/mipidsi/src/graphics/direct.rs
+++ b/mipidsi/src/graphics/direct.rs
@@ -1,0 +1,100 @@
+use embedded_graphics_core::{
+    draw_target::DrawTarget, geometry::Dimensions, primitives::Rectangle, Pixel,
+};
+use embedded_hal::digital::OutputPin;
+
+use super::{nth_u32, take_u32, TakeSkip};
+use crate::models::Model;
+use crate::{error::Error, Display};
+use display_interface::WriteOnlyDataCommand;
+
+impl<DI, M, RST> DrawTarget for Display<DI, M, RST>
+where
+    DI: WriteOnlyDataCommand,
+    M: Model,
+    RST: OutputPin,
+{
+    type Error = Error;
+    type Color = M::ColorFormat;
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            let x = pixel.0.x as u16;
+            let y = pixel.0.y as u16;
+
+            self.set_pixel(x, y, pixel.1)?;
+        }
+
+        Ok(())
+    }
+
+    fn fill_contiguous<I>(&mut self, area: &Rectangle, colors: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Self::Color>,
+    {
+        let intersection = area.intersection(&self.bounding_box());
+        let Some(bottom_right) = intersection.bottom_right() else {
+            // No intersection -> nothing to draw
+            return Ok(());
+        };
+
+        // Unchecked casting to u16 cannot fail here because the values are
+        // clamped to the display size which always fits in an u16.
+        let sx = intersection.top_left.x as u16;
+        let sy = intersection.top_left.y as u16;
+        let ex = bottom_right.x as u16;
+        let ey = bottom_right.y as u16;
+
+        let count = intersection.size.width * intersection.size.height;
+
+        let mut colors = colors.into_iter();
+
+        if &intersection == area {
+            // Draw the original iterator if no edge overlaps the framebuffer
+            self.set_pixels(sx, sy, ex, ey, take_u32(colors, count))
+        } else {
+            // Skip pixels above and to the left of the intersection
+            let mut initial_skip = 0;
+            if intersection.top_left.y > area.top_left.y {
+                initial_skip += intersection.top_left.y.abs_diff(area.top_left.y) * area.size.width;
+            }
+            if intersection.top_left.x > area.top_left.x {
+                initial_skip += intersection.top_left.x.abs_diff(area.top_left.x);
+            }
+            if initial_skip > 0 {
+                nth_u32(&mut colors, initial_skip - 1);
+            }
+
+            // Draw only the pixels which don't overlap the edges of the framebuffer
+            let take_per_row = intersection.size.width;
+            let skip_per_row = area.size.width - intersection.size.width;
+            self.set_pixels(
+                sx,
+                sy,
+                ex,
+                ey,
+                take_u32(TakeSkip::new(colors, take_per_row, skip_per_row), count),
+            )
+        }
+    }
+
+    fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
+        let area = area.intersection(&self.bounding_box());
+        let Some(bottom_right) = area.bottom_right() else {
+            // No intersection -> nothing to draw
+            return Ok(());
+        };
+
+        let count = area.size.width * area.size.height;
+        let mut colors = take_u32(core::iter::repeat(color), count);
+
+        let sx = area.top_left.x as u16;
+        let sy = area.top_left.y as u16;
+        let ex = bottom_right.x as u16;
+        let ey = bottom_right.y as u16;
+        self.set_pixels(sx, sy, ex, ey, &mut colors)
+    }
+}

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -116,7 +116,10 @@ pub mod dcs;
 pub mod models;
 use models::Model;
 
-mod graphics;
+///
+/// Embedded-graphics helpers and implementations
+///
+pub mod graphics;
 
 mod test_image;
 pub use test_image::TestImage;

--- a/mipidsi/src/models.rs
+++ b/mipidsi/src/models.rs
@@ -6,6 +6,7 @@ use crate::{
     options::ModelOptions,
 };
 use display_interface::WriteOnlyDataCommand;
+use embedded_graphics_core::pixelcolor::{raw::ToBytes, Rgb565, Rgb666};
 use embedded_graphics_core::prelude::RgbColor;
 use embedded_hal::{delay::DelayNs, digital::OutputPin};
 
@@ -73,4 +74,38 @@ pub trait Model {
     where
         DI: WriteOnlyDataCommand,
         I: IntoIterator<Item = Self::ColorFormat>;
+
+    /// Writes the same pixel to the given [u8] buffer. Returns byte size of the raw pixel
+    /// data or 0 if not implemented yet.
+    fn repeat_pixel_to_buffer(_color: Self::ColorFormat, _buf: &mut [u8]) -> Result<usize, Error> {
+        Ok(0)
+    }
+}
+
+// optimization helpers
+
+fn repeat_pixel_to_buffer_rgb565(color: Rgb565, buf: &mut [u8]) -> Result<usize, Error> {
+    let bytes = color.to_be_bytes();
+
+    repeat_pixel_to_buffer_bytes(&bytes, buf)
+}
+
+fn repeat_pixel_to_buffer_rgb666(color: Rgb666, buf: &mut [u8]) -> Result<usize, Error> {
+    let bytes = color.to_be_bytes();
+
+    repeat_pixel_to_buffer_bytes(&bytes, buf)
+}
+
+fn repeat_pixel_to_buffer_bytes(bytes: &[u8], buf: &mut [u8]) -> Result<usize, Error> {
+    let mut j = 0;
+    for val in buf {
+        *val = bytes[j];
+
+        j += 1;
+        if j >= bytes.len() {
+            j = 0;
+        }
+    }
+
+    Ok(bytes.len())
 }

--- a/mipidsi/src/models.rs
+++ b/mipidsi/src/models.rs
@@ -6,7 +6,6 @@ use crate::{
     options::ModelOptions,
 };
 use display_interface::WriteOnlyDataCommand;
-use embedded_graphics_core::pixelcolor::{raw::ToBytes, Rgb565, Rgb666};
 use embedded_graphics_core::prelude::RgbColor;
 use embedded_hal::{delay::DelayNs, digital::OutputPin};
 
@@ -77,35 +76,5 @@ pub trait Model {
 
     /// Writes the same pixel to the given [u8] buffer. Returns byte size of the raw pixel
     /// data or 0 if not implemented yet.
-    fn repeat_pixel_to_buffer(_color: Self::ColorFormat, _buf: &mut [u8]) -> Result<usize, Error> {
-        Ok(0)
-    }
-}
-
-// optimization helpers
-
-fn repeat_pixel_to_buffer_rgb565(color: Rgb565, buf: &mut [u8]) -> Result<usize, Error> {
-    let bytes = color.to_be_bytes();
-
-    repeat_pixel_to_buffer_bytes(&bytes, buf)
-}
-
-fn repeat_pixel_to_buffer_rgb666(color: Rgb666, buf: &mut [u8]) -> Result<usize, Error> {
-    let bytes = color.to_be_bytes();
-
-    repeat_pixel_to_buffer_bytes(&bytes, buf)
-}
-
-fn repeat_pixel_to_buffer_bytes(bytes: &[u8], buf: &mut [u8]) -> Result<usize, Error> {
-    let mut j = 0;
-    for val in buf {
-        *val = bytes[j];
-
-        j += 1;
-        if j >= bytes.len() {
-            j = 0;
-        }
-    }
-
-    Ok(bytes.len())
+    fn repeat_pixel_to_buffer(_color: Self::ColorFormat, _buf: &mut [u8]) -> Result<usize, Error>;
 }

--- a/mipidsi/src/models/gc9a01.rs
+++ b/mipidsi/src/models/gc9a01.rs
@@ -142,4 +142,8 @@ impl Model for GC9A01 {
         dcs.di.send_data(buf)?;
         Ok(())
     }
+
+    fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
+        super::repeat_pixel_to_buffer_rgb565(color, buf)
+    }
 }

--- a/mipidsi/src/models/gc9a01.rs
+++ b/mipidsi/src/models/gc9a01.rs
@@ -144,6 +144,6 @@ impl Model for GC9A01 {
     }
 
     fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
-        super::repeat_pixel_to_buffer_rgb565(color, buf)
+        crate::graphics::repeat_pixel_to_buffer_rgb565(color, buf)
     }
 }

--- a/mipidsi/src/models/ili9341.rs
+++ b/mipidsi/src/models/ili9341.rs
@@ -47,6 +47,10 @@ impl Model for ILI9341Rgb565 {
     {
         ili934x::write_pixels_rgb565(dcs, colors)
     }
+
+    fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
+        super::repeat_pixel_to_buffer_rgb565(color, buf)
+    }
 }
 
 impl Model for ILI9341Rgb666 {
@@ -80,5 +84,9 @@ impl Model for ILI9341Rgb666 {
         I: IntoIterator<Item = Self::ColorFormat>,
     {
         ili934x::write_pixels_rgb666(dcs, colors)
+    }
+
+    fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
+        super::repeat_pixel_to_buffer_rgb666(color, buf)
     }
 }

--- a/mipidsi/src/models/ili9341.rs
+++ b/mipidsi/src/models/ili9341.rs
@@ -49,7 +49,7 @@ impl Model for ILI9341Rgb565 {
     }
 
     fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
-        super::repeat_pixel_to_buffer_rgb565(color, buf)
+        crate::graphics::repeat_pixel_to_buffer_rgb565(color, buf)
     }
 }
 
@@ -87,6 +87,6 @@ impl Model for ILI9341Rgb666 {
     }
 
     fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
-        super::repeat_pixel_to_buffer_rgb666(color, buf)
+        crate::graphics::repeat_pixel_to_buffer_rgb666(color, buf)
     }
 }

--- a/mipidsi/src/models/ili9342c.rs
+++ b/mipidsi/src/models/ili9342c.rs
@@ -47,6 +47,10 @@ impl Model for ILI9342CRgb565 {
     {
         ili934x::write_pixels_rgb565(dcs, colors)
     }
+
+    fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
+        crate::graphics::repeat_pixel_to_buffer_rgb565(color, buf)
+    }
 }
 
 impl Model for ILI9342CRgb666 {
@@ -83,6 +87,6 @@ impl Model for ILI9342CRgb666 {
     }
 
     fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
-        super::repeat_pixel_to_buffer_rgb666(color, buf)
+        crate::graphics::repeat_pixel_to_buffer_rgb666(color, buf)
     }
 }

--- a/mipidsi/src/models/ili9342c.rs
+++ b/mipidsi/src/models/ili9342c.rs
@@ -81,4 +81,8 @@ impl Model for ILI9342CRgb666 {
     {
         ili934x::write_pixels_rgb666(dcs, colors)
     }
+
+    fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
+        super::repeat_pixel_to_buffer_rgb666(color, buf)
+    }
 }

--- a/mipidsi/src/models/ili9486.rs
+++ b/mipidsi/src/models/ili9486.rs
@@ -61,7 +61,7 @@ impl Model for ILI9486Rgb565 {
     }
 
     fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
-        super::repeat_pixel_to_buffer_rgb565(color, buf)
+        crate::graphics::repeat_pixel_to_buffer_rgb565(color, buf)
     }
 }
 
@@ -110,7 +110,7 @@ impl Model for ILI9486Rgb666 {
     }
 
     fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
-        super::repeat_pixel_to_buffer_rgb666(color, buf)
+        crate::graphics::repeat_pixel_to_buffer_rgb666(color, buf)
     }
 }
 

--- a/mipidsi/src/models/ili9486.rs
+++ b/mipidsi/src/models/ili9486.rs
@@ -59,6 +59,10 @@ impl Model for ILI9486Rgb565 {
         let buf = DataFormat::U16BEIter(&mut iter);
         dcs.di.send_data(buf)
     }
+
+    fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
+        super::repeat_pixel_to_buffer_rgb565(color, buf)
+    }
 }
 
 impl Model for ILI9486Rgb666 {
@@ -103,6 +107,10 @@ impl Model for ILI9486Rgb666 {
 
         let buf = DataFormat::U8Iter(&mut iter);
         dcs.di.send_data(buf)
+    }
+
+    fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
+        super::repeat_pixel_to_buffer_rgb666(color, buf)
     }
 }
 

--- a/mipidsi/src/models/st7735s.rs
+++ b/mipidsi/src/models/st7735s.rs
@@ -89,4 +89,8 @@ impl Model for ST7735s {
         dcs.di.send_data(buf)?;
         Ok(())
     }
+
+    fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
+        super::repeat_pixel_to_buffer_rgb565(color, buf)
+    }
 }

--- a/mipidsi/src/models/st7735s.rs
+++ b/mipidsi/src/models/st7735s.rs
@@ -91,6 +91,6 @@ impl Model for ST7735s {
     }
 
     fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
-        super::repeat_pixel_to_buffer_rgb565(color, buf)
+        crate::graphics::repeat_pixel_to_buffer_rgb565(color, buf)
     }
 }

--- a/mipidsi/src/models/st7789.rs
+++ b/mipidsi/src/models/st7789.rs
@@ -75,4 +75,8 @@ impl Model for ST7789 {
         dcs.di.send_data(buf)?;
         Ok(())
     }
+
+    fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
+        super::repeat_pixel_to_buffer_rgb565(color, buf)
+    }
 }

--- a/mipidsi/src/models/st7789.rs
+++ b/mipidsi/src/models/st7789.rs
@@ -77,6 +77,6 @@ impl Model for ST7789 {
     }
 
     fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
-        super::repeat_pixel_to_buffer_rgb565(color, buf)
+        crate::graphics::repeat_pixel_to_buffer_rgb565(color, buf)
     }
 }

--- a/mipidsi/src/models/st7796.rs
+++ b/mipidsi/src/models/st7796.rs
@@ -42,6 +42,6 @@ impl Model for ST7796 {
     }
 
     fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
-        super::repeat_pixel_to_buffer_rgb565(color, buf)
+        crate::graphics::repeat_pixel_to_buffer_rgb565(color, buf)
     }
 }

--- a/mipidsi/src/models/st7796.rs
+++ b/mipidsi/src/models/st7796.rs
@@ -40,4 +40,8 @@ impl Model for ST7796 {
     {
         super::ST7789.write_pixels(dcs, colors)
     }
+
+    fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
+        super::repeat_pixel_to_buffer_rgb565(color, buf)
+    }
 }

--- a/mipidsi/tests/external.rs
+++ b/mipidsi/tests/external.rs
@@ -73,4 +73,8 @@ impl Model for ExternalST7789 {
         dcs.di.send_data(buf)?;
         Ok(())
     }
+
+    fn repeat_pixel_to_buffer(color: Self::ColorFormat, buf: &mut [u8]) -> Result<usize, Error> {
+        mipidsi::graphics::repeat_pixel_to_buffer_rgb565(color, buf)
+    }
 }


### PR DESCRIPTION
This adds optimized (per color type) `fill_solid` paths as part of improving on issue #142.

This improved `fill_solid` fullscreen render speed on a `ST7789` using `80Mhz` SPI interface with `esp32-c6` board running at `160Mhz` CPU speed from `~48ms` to `~18ms`.

NOTE: the buffer size is arbitrarily chosen, bigger ones can get even better results, but I wanted to avoid using too much memory. If `batch` support is disabled these paths are not used. I hope we can come up with a better story for buffers overall in the future (e.g. wrt. to `display-interface` as well as this driver).