### PR TITLE
Add GC9107 driver support

### DIFF
--- a/mipidsi/CHANGELOG.md
+++ b/mipidsi/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - added `Display::set_pixels_from_buffer` to allow high performance display writes
+- added `GC9107` model support
 
 ## [v0.8.0] - 2024-05-24
 
@@ -52,7 +53,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
- - fixed MSRV in `Cargo.toml` to match the rest at `v1.61`
+- fixed MSRV in `Cargo.toml` to match the rest at `v1.61`
 
 ## [v0.7.0] - 2023-05-24
 
@@ -85,7 +86,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - added the `Builder` as construction method for displays to simplify configuration
-and protect against use-before-init bugs
+  and protect against use-before-init bugs
 - added `Model::default_options()` so that each model can provide a sane default regardless of helper constructors
 
 ### Changed
@@ -143,13 +144,15 @@ and protect against use-before-init bugs
 ## [v0.2.0] - 2021-04-12
 
 ### Changed
+
 - fix RGB/BGR color issue on some models
 - expand `Orientation` to use mirror image settings properly
 - change `Display::init` to include `DisplayOptions` and allow setting all `MADCTL` values on init, including `Orientation`
 - fix issues [#6](https://github.com/almindor/mipidsi/issues/6), [#8](https://github.com/almindor/mipidsi/issues/8) and [#10](https://github.com/almindor/mipidsi/issues/10)
-    - big thanks to [@brianmay](https://github.com/brianmay) and [@KerryRJ](https://github.com/KerryRJ)
+  - big thanks to [@brianmay](https://github.com/brianmay) and [@KerryRJ](https://github.com/KerryRJ)
 
 ## [v0.1.0] - 2021-09-09
 
 ### Added
+
 - Initial release

--- a/mipidsi/README.md
+++ b/mipidsi/README.md
@@ -13,9 +13,9 @@ Uses [display_interface](https://crates.io/crates/display-interface) to talk to 
 
 An optional batching of draws is supported via the `batch` feature (default on)
 
-*NOTES*:
+_NOTES_:
 
-* The name of this crate is a bit unfortunate as this driver works with displays that use the MIPI Display Command Set via any transport supported by [display_interface](https://crates.io/crates/display-interface) but MIPI Display Serial Interface is NOT supported at this time.
+- The name of this crate is a bit unfortunate as this driver works with displays that use the MIPI Display Command Set via any transport supported by [display_interface](https://crates.io/crates/display-interface) but MIPI Display Serial Interface is NOT supported at this time.
 
 ## License
 
@@ -35,13 +35,14 @@ Variants that require different screen sizes and window addressing offsets are n
 
 ### List of supported models
 
-* GC9A01
-* ILI9341
-* ILI9342C
-* ILI9486
-* ST7735
-* ST7789
-* ST7796
+- GC9107
+- GC9A01
+- ILI9341
+- ILI9342C
+- ILI9486
+- ST7735
+- ST7789
+- ST7796
 
 ## Migration
 
@@ -52,6 +53,7 @@ See [MIGRATION.md](../docs/MIGRATION.md) document.
 See [TROUBLESHOOTING.md](../docs/TROUBLESHOOTING.md) document.
 
 ### Example
+
 ```rust
 // create a DisplayInterface from SPI and DC pin, with no manual CS control
 let di = SPIInterfaceNoCS::new(spi, dc);
@@ -65,5 +67,5 @@ display.clear(Rgb666::BLACK)?;
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.75.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.75.0 and up. It _might_
 compile with older versions but that may change in any new patch release.

--- a/mipidsi/src/lib.rs
+++ b/mipidsi/src/lib.rs
@@ -12,6 +12,7 @@
 //!
 //! ### List of supported models
 //!
+//! * GC9107
 //! * GC9A01
 //! * ILI9341
 //! * ILI9342C
@@ -256,7 +257,7 @@ where
     /// the bottom right corner.
     ///
     /// <div class="warning">
-    ///    
+    ///
     /// This method is intended for advanced use cases where low level access to
     /// the displays framebuffer is required for performance reasons.  The
     /// caller must ensure the raw pixel data in `raw_buf` has the correct

--- a/mipidsi/src/models.rs
+++ b/mipidsi/src/models.rs
@@ -10,6 +10,7 @@ use embedded_graphics_core::prelude::RgbColor;
 use embedded_hal::delay::DelayNs;
 
 // existing model implementations
+mod gc9107;
 mod gc9a01;
 mod ili9341;
 mod ili9342c;
@@ -19,6 +20,7 @@ mod st7735s;
 mod st7789;
 mod st7796;
 
+pub use gc9107::*;
 pub use gc9a01::*;
 pub use ili9341::*;
 pub use ili9342c::*;

--- a/mipidsi/src/models/gc9107.rs
+++ b/mipidsi/src/models/gc9107.rs
@@ -1,0 +1,102 @@
+use display_interface::{DataFormat, WriteOnlyDataCommand};
+use embedded_graphics_core::{pixelcolor::Rgb565, prelude::IntoStorage};
+use embedded_hal::delay::DelayNs;
+
+use crate::{
+    dcs::{
+        BitsPerPixel, ExitSleepMode, PixelFormat, SetAddressMode, SetDisplayOn, SetInvertMode,
+        SetPixelFormat, WriteMemoryStart,
+    },
+    error::Error,
+    options::ModelOptions,
+};
+
+use super::{Dcs, Model};
+
+/// GC9107 display in Rgb565 color mode.
+pub struct GC9107;
+
+impl Model for GC9107 {
+    type ColorFormat = Rgb565;
+    const FRAMEBUFFER_SIZE: (u16, u16) = (128, 160);
+
+    fn init<DELAY, DI>(
+        &mut self,
+        dcs: &mut Dcs<DI>,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+    ) -> Result<SetAddressMode, Error>
+    where
+        DELAY: DelayNs,
+        DI: WriteOnlyDataCommand,
+    {
+        let madctl = SetAddressMode::from(options);
+
+        delay.delay_us(200_000);
+
+        dcs.write_command(madctl)?;
+
+        dcs.write_raw(0xB0, &[0xC0])?;
+        dcs.write_raw(0xB2, &[0x2F])?;
+        dcs.write_raw(0xB3, &[0x03])?;
+        dcs.write_raw(0xB6, &[0x19])?;
+        dcs.write_raw(0xB7, &[0x01])?;
+
+        dcs.write_raw(0xAC, &[0xCB])?;
+        dcs.write_raw(0xAB, &[0x0E])?;
+
+        dcs.write_raw(0xB4, &[0x04])?;
+
+        dcs.write_raw(0xA8, &[0x19])?;
+
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+        dcs.write_command(SetPixelFormat::new(pf))?;
+
+        dcs.write_raw(0xB8, &[0x08])?;
+
+        dcs.write_raw(0xE8, &[0x24])?;
+
+        dcs.write_raw(0xE9, &[0x48])?;
+
+        dcs.write_raw(0xEA, &[0x22])?;
+
+        dcs.write_raw(0xC6, &[0x30])?;
+        dcs.write_raw(0xC7, &[0x18])?;
+
+        dcs.write_raw(
+            0xF0,
+            &[
+                0x1F, 0x28, 0x04, 0x3E, 0x2A, 0x2E, 0x20, 0x00, 0x0C, 0x06, 0x00, 0x1C, 0x1F, 0x0f,
+            ],
+        )?;
+
+        dcs.write_raw(
+            0xF1,
+            &[
+                0x00, 0x2D, 0x2F, 0x3C, 0x6F, 0x1C, 0x0B, 0x00, 0x00, 0x00, 0x07, 0x0D, 0x11, 0x0f,
+            ],
+        )?;
+
+        dcs.write_command(SetInvertMode::new(options.invert_colors))?;
+
+        dcs.write_command(ExitSleepMode)?; // turn off sleep
+        delay.delay_us(120_000);
+
+        dcs.write_command(SetDisplayOn)?; // turn on display
+
+        Ok(madctl)
+    }
+
+    fn write_pixels<DI, I>(&mut self, dcs: &mut Dcs<DI>, colors: I) -> Result<(), Error>
+    where
+        DI: WriteOnlyDataCommand,
+        I: IntoIterator<Item = Self::ColorFormat>,
+    {
+        dcs.write_command(WriteMemoryStart)?;
+        let mut iter = colors.into_iter().map(|c| c.into_storage());
+
+        let buf = DataFormat::U16BEIter(&mut iter);
+        dcs.di.send_data(buf)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adding support for the GC9107 driver, commonly driving 0.85" panels in M5Stack Atom S3, [Waveshare 0.85](https://www.waveshare.com/0.85inch-lcd-module.htm) and [lilygo 0.85](https://lilygo.cc/products/t-0-85-inch-lcd-module?srsltid=AfmBOorMdpxSULatbRiVQFN5KDSUxl6Mp7JjAuNeu2UQV5qTiASrOVCM). Tested with Atom S3R and Waveshare 0.85.



![28307D0D-F9E1-4908-99B8-5CC8F40E349B 2](https://github.com/user-attachments/assets/191bd48c-ac32-4628-ae61-65d35137273d)
