### PR TITLE
ili9341: Add Bgr565 support

### DIFF
--- a/mipidsi/src/interface/mod.rs
+++ b/mipidsi/src/interface/mod.rs
@@ -1,7 +1,7 @@
 //! Interface traits and implementations
 
 mod spi;
-use embedded_graphics_core::pixelcolor::{Rgb565, Rgb666};
+use embedded_graphics_core::pixelcolor::{Bgr565, Rgb565, Rgb666};
 pub use spi::*;
 
 mod parallel;
@@ -67,6 +67,11 @@ impl<T: Interface> Interface for &mut T {
 fn rgb565_to_bytes(pixel: Rgb565) -> [u8; 2] {
     embedded_graphics_core::pixelcolor::raw::ToBytes::to_be_bytes(pixel)
 }
+
+fn bgr565_to_bytes(pixel: Bgr565) -> [u8; 2] {
+    embedded_graphics_core::pixelcolor::raw::ToBytes::to_be_bytes(pixel)
+}
+
 fn rgb565_to_u16(pixel: Rgb565) -> [u16; 1] {
     [u16::from_ne_bytes(
         embedded_graphics_core::pixelcolor::raw::ToBytes::to_ne_bytes(pixel),
@@ -95,6 +100,23 @@ pub trait InterfacePixelFormat<Word> {
         pixel: Self,
         count: u32,
     ) -> Result<(), DI::Error>;
+}
+
+impl InterfacePixelFormat<u8> for Bgr565 {
+    fn send_pixels<DI: Interface<Word = u8>>(
+        di: &mut DI,
+        pixels: impl IntoIterator<Item = Self>,
+    ) -> Result<(), DI::Error> {
+        di.send_pixels(pixels.into_iter().map(bgr565_to_bytes))
+    }
+
+    fn send_repeated_pixel<DI: Interface<Word = u8>>(
+        di: &mut DI,
+        pixel: Self,
+        count: u32,
+    ) -> Result<(), DI::Error> {
+        di.send_repeated_pixel(bgr565_to_bytes(pixel), count)
+    }
 }
 
 impl InterfacePixelFormat<u8> for Rgb565 {

--- a/mipidsi/src/models/ili9341.rs
+++ b/mipidsi/src/models/ili9341.rs
@@ -1,4 +1,4 @@
-use embedded_graphics_core::pixelcolor::{Rgb565, Rgb666};
+use embedded_graphics_core::pixelcolor::{Bgr565, Rgb565, Rgb666};
 use embedded_hal::delay::DelayNs;
 
 use crate::{
@@ -11,8 +11,30 @@ use crate::{
 /// ILI9341 display in Rgb565 color mode.
 pub struct ILI9341Rgb565;
 
+/// ILI9341 display in Bgr565 color mode.
+pub struct ILI9341Bgr565;
+
 /// ILI9341 display in Rgb666 color mode.
 pub struct ILI9341Rgb666;
+
+impl Model for ILI9341Bgr565 {
+    type ColorFormat = Bgr565;
+    const FRAMEBUFFER_SIZE: (u16, u16) = (240, 320);
+
+    fn init<DELAY, DI>(
+        &mut self,
+        di: &mut DI,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+    ) -> Result<SetAddressMode, DI::Error>
+    where
+        DELAY: DelayNs,
+        DI: Interface,
+    {
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+        ili934x::init_common(di, delay, options, pf).map_err(Into::into)
+    }
+}
 
 impl Model for ILI9341Rgb565 {
     type ColorFormat = Rgb565;


### PR DESCRIPTION
Some devices like some Waveshare LCD Modules use the BGR565 pixel format.

Make sure it is supported.