### PR TITLE
Make `InitError` visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - added `RM67162` model support
+- made `InitError` visible
 
 ## Removed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ use interface::InterfacePixelFormat;
 use options::MemoryMapping;
 
 mod builder;
-pub use builder::{Builder, NoResetPin};
+pub use builder::*;
 
 pub mod dcs;
 


### PR DESCRIPTION
Although `InitError` was marked as pub, it wasn't exported outside the non-pub `Builder` module.

`pub use builder::*;` means that any future pub items will also be exported to the root of the crate, but non-pub items won't.