### PR TITLE
Add KIND contant to Interface trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - added `RM67162` model support
 - made `InitError` visible
 - added `ILI9488` model support
+- added `KIND` constant to `Interface` trait to detect invalid model, color format, and interface combinations
 
 ## Removed
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -19,6 +19,9 @@ pub trait Interface {
     /// Error type
     type Error: core::fmt::Debug;
 
+    /// Kind
+    const KIND: InterfaceKind;
+
     /// Send a command with optional parameters
     fn send_command(&mut self, command: u8, args: &[u8]) -> Result<(), Self::Error>;
 
@@ -43,6 +46,8 @@ pub trait Interface {
 impl<T: Interface> Interface for &mut T {
     type Word = T::Word;
     type Error = T::Error;
+
+    const KIND: InterfaceKind = T::KIND;
 
     fn send_command(&mut self, command: u8, args: &[u8]) -> Result<(), Self::Error> {
         T::send_command(self, command, args)
@@ -146,4 +151,30 @@ impl InterfacePixelFormat<u16> for Rgb565 {
     ) -> Result<(), DI::Error> {
         di.send_repeated_pixel(rgb565_to_u16(pixel), count)
     }
+}
+
+/// Interface kind.
+///
+/// Specifies the kind of physical connection to the display controller that is
+/// supported by this interface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InterfaceKind {
+    /// Serial interface with data/command pin.
+    ///
+    /// SPI style interface with 8 bits per word and an additional pin to
+    /// distinguish between data and command words.
+    Serial4Line,
+
+    /// 8 bit parallel interface.
+    ///
+    /// 8080 style parallel interface with 8 data pins and chip select, write enable,
+    /// and command/data signals.
+    Parallel8Bit,
+
+    /// 16 bit parallel interface.
+    ///
+    /// 8080 style parallel interface with 16 data pins and chip select, write enable,
+    /// and command/data signals.
+    Parallel16Bit,
 }

--- a/src/interface/spi.rs
+++ b/src/interface/spi.rs
@@ -1,6 +1,6 @@
 use embedded_hal::{digital::OutputPin, spi::SpiDevice};
 
-use super::Interface;
+use super::{Interface, InterfaceKind};
 
 /// Spi interface error
 #[derive(Clone, Copy, Debug)]
@@ -35,6 +35,8 @@ impl<'a, SPI: SpiDevice, DC: OutputPin> SpiInterface<'a, SPI, DC> {
 impl<SPI: SpiDevice, DC: OutputPin> Interface for SpiInterface<'_, SPI, DC> {
     type Word = u8;
     type Error = SpiError<SPI::Error, DC::Error>;
+
+    const KIND: InterfaceKind = InterfaceKind::Serial4Line;
 
     fn send_command(&mut self, command: u8, args: &[u8]) -> Result<(), Self::Error> {
         self.dc.set_low().map_err(SpiError::Dc)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,7 +393,11 @@ pub mod _mock {
 
     use embedded_hal::{delay::DelayNs, digital, spi};
 
-    use crate::{interface::Interface, models::ILI9341Rgb565, Builder, Display, NoResetPin};
+    use crate::{
+        interface::{Interface, InterfaceKind},
+        models::ILI9341Rgb565,
+        Builder, Display, NoResetPin,
+    };
 
     pub fn new_mock_display() -> Display<MockDisplayInterface, ILI9341Rgb565, NoResetPin> {
         Builder::new(ILI9341Rgb565, MockDisplayInterface)
@@ -443,6 +447,8 @@ pub mod _mock {
     impl Interface for MockDisplayInterface {
         type Word = u8;
         type Error = Infallible;
+
+        const KIND: InterfaceKind = InterfaceKind::Serial4Line;
 
         fn send_command(&mut self, _command: u8, _args: &[u8]) -> Result<(), Self::Error> {
             Ok(())

--- a/src/models/gc9107.rs
+++ b/src/models/gc9107.rs
@@ -29,6 +29,8 @@ impl Model for GC9107 {
         DELAY: DelayNs,
         DI: Interface,
     {
+        assert_interface_kind!(Serial4Line | Parallel8Bit);
+
         delay.delay_ms(200);
 
         di.write_raw(0xFE, &[])?;

--- a/src/models/gc9a01.rs
+++ b/src/models/gc9a01.rs
@@ -29,6 +29,8 @@ impl Model for GC9A01 {
         DELAY: DelayNs,
         DI: Interface,
     {
+        assert_interface_kind!(Serial4Line | Parallel8Bit | Parallel16Bit);
+
         let madctl = SetAddressMode::from(options);
 
         delay.delay_us(200_000);

--- a/src/models/ili9341.rs
+++ b/src/models/ili9341.rs
@@ -28,6 +28,8 @@ impl Model for ILI9341Rgb565 {
         DELAY: DelayNs,
         DI: Interface,
     {
+        assert_interface_kind!(Serial4Line | Parallel8Bit | Parallel16Bit);
+
         let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
         ili934x::init_common(di, delay, options, pf).map_err(Into::into)
     }
@@ -47,6 +49,8 @@ impl Model for ILI9341Rgb666 {
         DELAY: DelayNs,
         DI: Interface,
     {
+        assert_interface_kind!(Serial4Line | Parallel8Bit | Parallel16Bit);
+
         let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
         ili934x::init_common(di, delay, options, pf).map_err(Into::into)
     }

--- a/src/models/ili9342c.rs
+++ b/src/models/ili9342c.rs
@@ -28,6 +28,8 @@ impl Model for ILI9342CRgb565 {
         DELAY: DelayNs,
         DI: Interface,
     {
+        assert_interface_kind!(Serial4Line | Parallel8Bit | Parallel16Bit);
+
         let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
         ili934x::init_common(di, delay, options, pf).map_err(Into::into)
     }
@@ -47,6 +49,8 @@ impl Model for ILI9342CRgb666 {
         DELAY: DelayNs,
         DI: Interface,
     {
+        assert_interface_kind!(Serial4Line | Parallel8Bit | Parallel16Bit);
+
         let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
         ili934x::init_common(di, delay, options, pf).map_err(Into::into)
     }

--- a/src/models/ili9486.rs
+++ b/src/models/ili9486.rs
@@ -29,6 +29,8 @@ impl Model for ILI9486Rgb565 {
         DELAY: DelayNs,
         DI: Interface,
     {
+        assert_interface_kind!(Parallel8Bit | Parallel16Bit);
+
         delay.delay_us(120_000);
 
         let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
@@ -50,6 +52,8 @@ impl Model for ILI9486Rgb666 {
         DELAY: DelayNs,
         DI: Interface,
     {
+        assert_interface_kind!(Serial4Line | Parallel8Bit | Parallel16Bit);
+
         delay.delay_us(120_000);
 
         let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());

--- a/src/models/ili9488.rs
+++ b/src/models/ili9488.rs
@@ -29,6 +29,8 @@ impl Model for ILI9488Rgb565 {
         DELAY: DelayNs,
         DI: Interface,
     {
+        assert_interface_kind!(Serial4Line | Parallel8Bit | Parallel16Bit);
+
         delay.delay_us(120_000);
 
         let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
@@ -50,6 +52,8 @@ impl Model for ILI9488Rgb666 {
         DELAY: DelayNs,
         DI: Interface,
     {
+        assert_interface_kind!(Serial4Line | Parallel8Bit | Parallel16Bit);
+
         delay.delay_us(120_000);
 
         let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());

--- a/src/models/rm67162.rs
+++ b/src/models/rm67162.rs
@@ -41,6 +41,8 @@ impl Model for RM67162 {
         DELAY: DelayNs,
         DI: Interface,
     {
+        assert_interface_kind!(Serial4Line | Parallel8Bit);
+
         let madctl = SetAddressMode::from(options);
 
         di.write_raw(0xFE, &[0x04])?;

--- a/src/models/st7735s.rs
+++ b/src/models/st7735s.rs
@@ -28,6 +28,8 @@ impl Model for ST7735s {
         DELAY: DelayNs,
         DI: Interface,
     {
+        assert_interface_kind!(Serial4Line | Parallel8Bit | Parallel16Bit);
+
         let madctl = SetAddressMode::from(options);
 
         delay.delay_us(200_000);

--- a/src/models/st7789.rs
+++ b/src/models/st7789.rs
@@ -28,6 +28,8 @@ impl Model for ST7789 {
         DELAY: DelayNs,
         DI: Interface,
     {
+        assert_interface_kind!(Serial4Line | Parallel8Bit | Parallel16Bit);
+
         let madctl = SetAddressMode::from(options);
 
         delay.delay_us(150_000);

--- a/src/models/st7796.rs
+++ b/src/models/st7796.rs
@@ -20,6 +20,8 @@ impl Model for ST7796 {
         DELAY: DelayNs,
         DI: Interface,
     {
+        assert_interface_kind!(Serial4Line | Parallel8Bit | Parallel16Bit);
+
         super::ST7789.init(di, delay, options)
     }
 }


### PR DESCRIPTION
This PR adds the interface kind constant to the `Interface` trait as discussed in #167.

I've decided to not extend the `InitError` enum and just panic instead. It should only be possible to encounter this error during development time, when the programmer wasn't aware that the combination of controller model, color format, and interface kind isn't supported.