### PR TITLE
add SpiInterfaceAsync with flush

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,12 @@ jobs:
       - name: Run tests
         run: |
           cargo test
+      - name: Run tests with all features
+        run: |
+          cargo test --all-features
+      - name: Run tests without default features
+        run: |
+          cargo test --no-default-features
 
   # On macOS and Windows, we at least make sure that the crate builds and links.
   build-other:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- added `async` feature with `SpiInterfaceAsync` implementation behind it
 - added `SpiInterface::release`
 - added `RM67162` model support
 - made `InitError` visible

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,20 @@ documentation = "https://docs.rs/mipidsi"
 rust-version = "1.75"
 
 [dependencies]
-embassy-futures = "0.1.1"
 embedded-graphics-core = "0.4.0"
 embedded-hal = "1.0.0"
-embedded-hal-async = "1.0.0"
 
 [dependencies.heapless]
 optional = true
 version = "0.8.0"
+
+[dependencies.embassy-futures]
+optional = true
+version = "0.1.1"
+
+[dependencies.embedded-hal-async]
+optional = true
+version = "1.0.0"
 
 [dev-dependencies]
 embedded-graphics = "0.8.1"
@@ -27,6 +33,7 @@ embedded-graphics = "0.8.1"
 [features]
 default = ["batch"]
 batch = ["heapless"]
+async = ["embassy-futures", "embedded-hal-async"]
 
 [workspace]
 members = ["mipidsi-async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,10 @@ documentation = "https://docs.rs/mipidsi"
 rust-version = "1.75"
 
 [dependencies]
+embassy-futures = "0.1.1"
 embedded-graphics-core = "0.4.0"
 embedded-hal = "1.0.0"
+embedded-hal-async = "1.0.0"
 
 [dependencies.heapless]
 optional = true

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,8 +1,10 @@
 //! Interface traits and implementations
+use embedded_graphics_core::pixelcolor::{Rgb565, Rgb666, RgbColor};
 
 mod spi;
-use embedded_graphics_core::pixelcolor::{Rgb565, Rgb666, RgbColor};
+mod spi_async;
 pub use spi::*;
+pub use spi_async::*;
 
 mod parallel;
 pub use parallel::*;
@@ -41,6 +43,12 @@ pub trait Interface {
         pixel: [Self::Word; N],
         count: u32,
     ) -> Result<(), Self::Error>;
+}
+
+/// Pixel interface that writes to a intermediate buffer and provides an async flush
+pub trait FlushingInterface: Interface {
+    /// Flushes stored pixel data to the interface
+    fn flush(&mut self) -> impl core::future::Future<Output = Result<(), Self::Error>>;
 }
 
 impl<T: Interface> Interface for &mut T {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,13 +1,15 @@
 //! Interface traits and implementations
 use embedded_graphics_core::pixelcolor::{Rgb565, Rgb666, RgbColor};
 
-mod spi;
-mod spi_async;
-pub use spi::*;
-pub use spi_async::*;
-
 mod parallel;
+mod spi;
+#[cfg(feature = "async")]
+mod spi_async;
+
 pub use parallel::*;
+pub use spi::*;
+#[cfg(feature = "async")]
+pub use spi_async::*;
 
 /// Command and pixel interface
 pub trait Interface {

--- a/src/interface/spi_async.rs
+++ b/src/interface/spi_async.rs
@@ -1,0 +1,101 @@
+use embedded_hal::{digital::OutputPin, spi::SpiDevice};
+
+use super::{FlushingInterface, Interface, InterfaceKind, SpiError};
+
+/// Async Spi interface, including a dma buffer
+///
+/// The buffer should be a DMA buffer and is used to gather batches of pixel data to be sent over SPI.
+/// The buffer should be large enough to accommodate the framebuffer size of the Display.
+pub struct SpiInterfaceAsync<'a, SPI, DC> {
+    spi: SPI,
+    dc: DC,
+    buffer: &'a mut [u8],
+    index: usize,
+}
+
+impl<'a, SPI: SpiDevice, DC: OutputPin> SpiInterfaceAsync<'a, SPI, DC> {
+    /// Create new interface
+    pub fn new(spi: SPI, dc: DC, buffer: &'a mut [u8]) -> Self {
+        // TODO: we should probably do at least an assertion of basic size requirement for the
+        // buffer here.
+        Self {
+            spi,
+            dc,
+            buffer,
+            index: 0,
+        }
+    }
+}
+
+impl<SPI, DC> Interface for SpiInterfaceAsync<'_, SPI, DC>
+where
+    SPI: SpiDevice,
+    DC: OutputPin,
+{
+    type Word = u8;
+    type Error = SpiError<SPI::Error, DC::Error>;
+
+    const KIND: InterfaceKind = InterfaceKind::Serial4Line;
+
+    fn send_command(&mut self, command: u8, args: &[u8]) -> Result<(), Self::Error> {
+        self.dc.set_low().map_err(SpiError::Dc)?;
+        self.spi.write(&[command]).map_err(SpiError::Spi)?;
+        self.dc.set_high().map_err(SpiError::Dc)?;
+        self.spi.write(args).map_err(SpiError::Spi)?;
+
+        Ok(())
+    }
+
+    fn send_pixels<const N: usize>(
+        &mut self,
+        pixels: impl IntoIterator<Item = [Self::Word; N]>,
+    ) -> Result<(), Self::Error> {
+        let mut arrays = pixels.into_iter();
+
+        for chunk in self.buffer.chunks_exact_mut(N) {
+            if let Some(array) = arrays.next() {
+                let chunk: &mut [u8; N] = chunk.try_into().unwrap();
+                *chunk = array;
+                self.index += N;
+            } else {
+                break;
+            };
+        }
+
+        Ok(())
+    }
+
+    fn send_repeated_pixel<const N: usize>(
+        &mut self,
+        pixel: [Self::Word; N],
+        count: u32,
+    ) -> Result<(), Self::Error> {
+        let fill_count = core::cmp::min(count, (self.buffer.len() / N) as u32);
+        let filled_len = fill_count as usize * N;
+
+        for chunk in self.buffer[self.index..(self.index + filled_len)].chunks_exact_mut(N) {
+            let chunk: &mut [u8; N] = chunk.try_into().unwrap();
+            *chunk = pixel;
+        }
+
+        self.index += filled_len;
+
+        Ok(())
+    }
+}
+
+impl<SPI, DC> FlushingInterface for SpiInterfaceAsync<'_, SPI, DC>
+where
+    SPI: SpiDevice,
+    DC: OutputPin,
+{
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        self.spi
+            .write(&self.buffer[..self.index])
+            .map_err(SpiError::Spi)?;
+
+        self.index = 0;
+
+        Ok(())
+    }
+}

--- a/src/interface/spi_async.rs
+++ b/src/interface/spi_async.rs
@@ -9,17 +9,18 @@ use super::{FlushingInterface, Interface, InterfaceKind, SpiError};
 /// Async Spi interface, including a dma buffer
 ///
 /// The buffer should be a DMA buffer and is used to gather batches of pixel data to be sent over SPI.
-/// The buffer should be large enough to accommodate the framebuffer size of the Display.
+/// The buffer should be large enough to accommodate the `display_size` of the [crate::Display].
 pub struct SpiInterfaceAsync<'a, SPI, DC> {
     spi: SPI,
     dc: DC,
     buffer: &'a mut [u8],
-    index: usize,
     // drawing window minmax values
-    sx: u16,
-    ex: u16,
-    sy: u16,
-    ey: u16,
+    max_window_extents: WindowExtents,
+    // last drawing window
+    last_window_extents: WindowExtents,
+    // display size
+    display_size: (usize, usize),
+    pixel_bytes: usize,
 }
 
 impl<'a, SPI, DC> SpiInterfaceAsync<'a, SPI, DC>
@@ -27,19 +28,21 @@ where
     SPI: SpiDevice,
     DC: OutputPin,
 {
-    /// Create new interface
-    pub fn new(spi: SPI, dc: DC, buffer: &'a mut [u8]) -> Self {
-        // TODO: we should probably do at least an assertion of basic size requirement for the
-        // buffer here.
+    /// Create new interface with given buffer and display size
+    ///
+    /// # Warning
+    /// User must ensure that `buffer` size `display_size` correspond correctly.
+    /// If `buffer` is smaller than `display_size` * "byte size of pixel" this interface
+    /// will cause a panic during drawing operations.
+    pub fn new(spi: SPI, dc: DC, buffer: &'a mut [u8], display_size: (usize, usize)) -> Self {
         Self {
             spi,
             dc,
             buffer,
-            index: 0,
-            sx: u16::MAX,
-            ex: 0,
-            sy: u16::MAX,
-            ey: 0,
+            max_window_extents: WindowExtents::default_max(),
+            last_window_extents: WindowExtents::default(),
+            display_size,
+            pixel_bytes: 0,
         }
     }
 
@@ -68,13 +71,14 @@ where
     const KIND: InterfaceKind = InterfaceKind::Serial4Line;
 
     fn send_command(&mut self, command: u8, args: &[u8]) -> Result<(), Self::Error> {
+        // we must ensure drawing window sets are captured
         match command {
             // SetColumnAddress
             0x2A => {
                 let sx = u16::from_be_bytes([args[0], args[1]]);
                 let ex = u16::from_be_bytes([args[2], args[3]]);
-                self.sx = core::cmp::min(self.sx, sx);
-                self.ex = core::cmp::max(self.ex, ex);
+                self.max_window_extents.apply_column_max(sx, ex);
+                self.last_window_extents.x = (sx, ex);
 
                 return Ok(());
             }
@@ -82,13 +86,11 @@ where
             0x2B => {
                 let sy = u16::from_be_bytes([args[0], args[1]]);
                 let ey = u16::from_be_bytes([args[2], args[3]]);
-                self.sy = core::cmp::min(self.sy, sy);
-                self.ey = core::cmp::max(self.ey, ey);
+                self.max_window_extents.apply_page_max(sy, ey);
+                self.last_window_extents.y = (sy, ey);
 
                 return Ok(());
             }
-            // WriteMemory
-            0x2C => {} // do nothing atm.
             _ => {}
         }
 
@@ -99,16 +101,24 @@ where
         &mut self,
         pixels: impl IntoIterator<Item = [Self::Word; N]>,
     ) -> Result<(), Self::Error> {
-        let mut arrays = pixels.into_iter();
+        self.pixel_bytes = N; // TODO: refactor
 
-        for chunk in self.buffer.chunks_exact_mut(N) {
-            if let Some(array) = arrays.next() {
-                let chunk: &mut [u8; N] = chunk.try_into().unwrap();
-                *chunk = array;
-                self.index += N;
-            } else {
-                break;
-            };
+        let mut arrays = pixels.into_iter();
+        let mut lines = ExtentsRowIterator::default();
+
+        while let Some((start_index, end_index)) = lines.next(
+            &self.last_window_extents,
+            self.display_size,
+            self.pixel_bytes,
+        ) {
+            for chunk in self.buffer[start_index..end_index].chunks_exact_mut(N) {
+                if let Some(array) = arrays.next() {
+                    let chunk: &mut [u8; N] = chunk.try_into().unwrap();
+                    *chunk = array;
+                } else {
+                    break;
+                };
+            }
         }
 
         Ok(())
@@ -117,17 +127,21 @@ where
     fn send_repeated_pixel<const N: usize>(
         &mut self,
         pixel: [Self::Word; N],
-        count: u32,
+        _count: u32,
     ) -> Result<(), Self::Error> {
-        let fill_count = core::cmp::min(count, (self.buffer.len() / N) as u32);
-        let filled_len = fill_count as usize * N;
+        self.pixel_bytes = N; // TODO: refactor
 
-        for chunk in self.buffer[self.index..(self.index + filled_len)].chunks_exact_mut(N) {
-            let chunk: &mut [u8; N] = chunk.try_into().unwrap();
-            *chunk = pixel;
+        let mut lines = ExtentsRowIterator::default();
+        while let Some((start_index, end_index)) = lines.next(
+            &self.last_window_extents,
+            self.display_size,
+            self.pixel_bytes,
+        ) {
+            for chunk in self.buffer[start_index..end_index].chunks_exact_mut(N) {
+                let chunk: &mut [u8; N] = chunk.try_into().unwrap();
+                *chunk = pixel;
+            }
         }
-
-        self.index += filled_len;
 
         Ok(())
     }
@@ -141,23 +155,150 @@ where
     async fn flush(&mut self) -> Result<(), Self::Error> {
         let mut param_bytes: [u8; 16] = [0; 16];
 
-        let sca = SetColumnAddress::new(self.sx, self.ex);
+        // set drawing window based on max_window_extents
+        let sca = SetColumnAddress::new(self.max_window_extents.x.0, self.max_window_extents.x.1);
         let n = sca.fill_params_buf(&mut param_bytes);
         self.send_command_inner(sca.instruction(), &param_bytes[..n])?;
 
-        let spa = SetPageAddress::new(self.sy, self.ey);
+        let spa = SetPageAddress::new(self.max_window_extents.y.0, self.max_window_extents.y.1);
         let n = spa.fill_params_buf(&mut param_bytes);
         self.send_command_inner(spa.instruction(), &param_bytes[..n])?;
 
+        // draw area of max_window_extents from buffer
         self.send_command_inner(WriteMemoryStart.instruction(), &[])?;
 
-        self.spi
-            .write(&self.buffer[..self.index])
-            .await
-            .map_err(SpiError::Spi)?;
+        let mut lines = ExtentsRowIterator::default();
+        while let Some((start_index, end_index)) = lines.next(
+            &self.max_window_extents,
+            self.display_size,
+            self.pixel_bytes,
+        ) {
+            self.spi
+                .write(&self.buffer[start_index..end_index])
+                .await
+                .map_err(SpiError::Spi)?;
+        }
 
-        self.index = 0;
-
+        // reset the max extents
+        self.max_window_extents = WindowExtents::default_max();
         Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+struct WindowExtents {
+    x: (u16, u16),
+    y: (u16, u16),
+}
+
+impl WindowExtents {
+    fn default_max() -> Self {
+        Self {
+            x: (u16::MAX, 0),
+            y: (u16::MAX, 0),
+        }
+    }
+
+    fn apply_column_max(&mut self, sx: u16, ex: u16) {
+        self.x.0 = core::cmp::min(self.x.0, sx);
+        self.x.1 = core::cmp::max(self.x.1, ex);
+    }
+
+    fn apply_page_max(&mut self, sy: u16, ey: u16) {
+        self.y.0 = core::cmp::min(self.y.0, sy);
+        self.y.1 = core::cmp::max(self.y.1, ey);
+    }
+}
+
+#[derive(Default, Debug)]
+struct ExtentsRowIterator(usize);
+
+impl ExtentsRowIterator {
+    pub fn next(
+        &mut self,
+        extents: &WindowExtents,
+        display_size: (usize, usize),
+        pixel_bytes: usize,
+    ) -> Option<(usize, usize)> {
+        if self.0 + extents.y.0 as usize > extents.y.1 as usize {
+            return None;
+        }
+
+        // these are all in pixel counts
+        let start_x = extents.x.0 as usize;
+        let start_y = extents.y.0 as usize + self.0;
+        let size_x = (extents.x.1 - extents.x.0 + 1) as usize;
+
+        // these are in byte counts
+        let start_index = (start_x + display_size.0 * start_y) * pixel_bytes;
+        let end_index = start_index + (size_x * pixel_bytes);
+
+        self.0 += 1;
+        Some((start_index, end_index))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const PIXEL_BYTES: usize = 2;
+    const DISPLAY_SIZE: (usize, usize) = (240, 130);
+
+    #[test]
+    fn test_zero_extents_row_iterator() {
+        let extents = WindowExtents {
+            x: (0, 0),
+            y: (0, 0),
+        };
+
+        let mut iter = ExtentsRowIterator::default();
+
+        if let Some((start_index, end_index)) = iter.next(&extents, DISPLAY_SIZE, PIXEL_BYTES) {
+            assert_eq!(start_index, 0);
+            assert_eq!(end_index, 2);
+        } else {
+            panic!("iterator did not return a value");
+        }
+
+        assert_eq!(iter.next(&extents, DISPLAY_SIZE, PIXEL_BYTES), None);
+    }
+
+    #[test]
+    fn test_empty_extents_row_iterator() {
+        let extents = WindowExtents {
+            x: (44, 44),
+            y: (33, 33),
+        };
+
+        let mut iter = ExtentsRowIterator::default();
+
+        if let Some((start_index, end_index)) = iter.next(&extents, DISPLAY_SIZE, PIXEL_BYTES) {
+            assert_eq!(start_index, (33 * DISPLAY_SIZE.0 + 44) * PIXEL_BYTES);
+            assert_eq!(end_index, start_index + PIXEL_BYTES);
+        } else {
+            panic!("iterator did not return a value");
+        }
+
+        assert_eq!(iter.next(&extents, DISPLAY_SIZE, PIXEL_BYTES), None);
+    }
+
+    #[test]
+    fn test_rect_extents_row_iterator() {
+        let extents = WindowExtents {
+            x: (55, 57),
+            y: (33, 33),
+        };
+
+        let mut iter = ExtentsRowIterator::default();
+
+        if let Some((start_index, end_index)) = iter.next(&extents, DISPLAY_SIZE, PIXEL_BYTES) {
+            assert_eq!(start_index, (33 * DISPLAY_SIZE.0 + 55) * PIXEL_BYTES);
+            assert_eq!(end_index, start_index + 3 * PIXEL_BYTES);
+        } else {
+            panic!("iterator did not return a value");
+        }
+
+        assert_eq!(iter.next(&extents, DISPLAY_SIZE, PIXEL_BYTES), None);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,6 +384,19 @@ where
     }
 }
 
+impl<DI, M, RST> Display<DI, M, RST>
+where
+    DI: interface::FlushingInterface,
+    M: Model,
+    M::ColorFormat: InterfacePixelFormat<DI::Word>,
+    RST: OutputPin,
+{
+    /// Flushes the framebuffer to the underlaying display interface
+    pub async fn flush(&mut self) -> Result<(), DI::Error> {
+        self.di.flush().await
+    }
+}
+
 /// Mock implementations of embedded-hal and interface traits.
 ///
 /// Do not use types in this module outside of doc tests.


### PR DESCRIPTION
This PR adds a buffered `SpiInterfaceAsync` struct and `FlushingInterface` trait to enable fully buffered operations in async context with use of manual `flush()` method.

NOTE: I'm unsure if we want to generalize buffering over ALL interfaces with something like `with_framebuffer()` constructor additions since performance wise it can be an improvment if the MCU has the RAM to spare, even without async.