### PR TITLE
implement Async version of mipidsi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,17 +14,15 @@ rust-version = "1.75"
 [dependencies]
 embedded-graphics-core = "0.4.0"
 embedded-hal = "1.0.0"
-
-[dependencies.heapless]
-optional = true
-version = "0.8.0"
+embedded-hal-async = "1.0.0"
+heapless = "0.8.0"
 
 [dev-dependencies]
 embedded-graphics = "0.8.1"
 
 [features]
 default = ["batch"]
-batch = ["heapless"]
+batch = []
 
 [workspace]
 members = ["mipidsi-async"]

--- a/src/dcs.rs
+++ b/src/dcs.rs
@@ -1,7 +1,5 @@
 //! MIPI DCS commands.
 
-use crate::interface::Interface;
-
 #[macro_use]
 mod macros;
 
@@ -32,38 +30,6 @@ pub trait DcsCommand {
     /// Fills the given buffer with the command parameters.
     fn fill_params_buf(&self, buffer: &mut [u8]) -> usize;
 }
-
-/// An extension trait for [`Interface`] with support for writing DCS commands.
-///
-/// Commands which are part of the manufacturer independent user command set can be sent to the
-/// display by using the [`write_command`](Self::write_command) method with one of the command types
-/// in this module.
-///
-/// All other commands, which do not have an associated type in this module, can be sent using
-/// the [`write_raw`](Self::write_raw) method.
-pub trait InterfaceExt: Interface {
-    /// Sends a DCS command to the display interface.
-    fn write_command(&mut self, command: impl DcsCommand) -> Result<(), Self::Error> {
-        let mut param_bytes: [u8; 16] = [0; 16];
-        let n = command.fill_params_buf(&mut param_bytes);
-        self.write_raw(command.instruction(), &param_bytes[..n])
-    }
-
-    /// Sends a raw command with the given `instruction` to the display interface.
-    ///
-    /// The `param_bytes` slice can contain the instruction parameters, which are sent as data after
-    /// the instruction code was sent. If no parameters are required an empty slice can be passed to
-    /// this method.
-    ///
-    /// This method is intended to be used for sending commands which are not part of the MIPI DCS
-    /// user command set. Use [`write_command`](Self::write_command) for commands in the user
-    /// command set.
-    fn write_raw(&mut self, instruction: u8, param_bytes: &[u8]) -> Result<(), Self::Error> {
-        self.send_command(instruction, param_bytes)
-    }
-}
-
-impl<T: Interface> InterfaceExt for T {}
 
 // DCS commands that don't use any parameters
 

--- a/src/display_async.rs
+++ b/src/display_async.rs
@@ -1,0 +1,323 @@
+use embedded_graphics_core::{
+    prelude::{Dimensions, DrawTarget, OriginDimensions, Size},
+    primitives::Rectangle,
+    Pixel,
+};
+use embedded_hal::digital::OutputPin;
+use embedded_hal_async::delay::DelayNs;
+
+use crate::{
+    dcs,
+    framebuffer::{ExtentsRowIterator, WindowExtents},
+    graphics::{nth_u32, take_u32, TakeSkip},
+    interface::{InterfaceAsync, InterfacePixelFormat},
+    models::Model,
+    options::{self, ModelOptions, Orientation},
+};
+
+///
+/// Async Display driver to connect to TFT displays.
+///
+pub struct DisplayAsync<'buffer, DI, MODEL, RST>
+where
+    DI: InterfaceAsync,
+    MODEL: Model,
+    MODEL::ColorFormat: InterfacePixelFormat<DI::Word>,
+    RST: OutputPin,
+{
+    // DCS provider
+    pub(crate) di: DI,
+    // Model
+    pub(crate) model: MODEL,
+    // Reset pin
+    pub(crate) rst: Option<RST>,
+    // Model Options, includes current orientation
+    pub(crate) options: ModelOptions,
+    // Current MADCTL value copy for runtime updates
+    pub(crate) madctl: dcs::SetAddressMode,
+    // State monitor for sleeping TODO: refactor to a Model-connected state machine
+    pub(crate) sleeping: bool,
+    // drawing window minmax values
+    pub(crate) max_window_extents: WindowExtents,
+    // last drawing window
+    pub(crate) last_window_extents: WindowExtents,
+    // framebuffer
+    pub(crate) buffer: &'buffer mut [u8],
+}
+
+impl<DI, M, RST> DisplayAsync<'_, DI, M, RST>
+where
+    DI: InterfaceAsync,
+    M: Model,
+    M::ColorFormat: InterfacePixelFormat<DI::Word>,
+    RST: OutputPin,
+{
+    ///
+    /// Returns currently set [options::Orientation]
+    ///
+    pub fn orientation(&self) -> Orientation {
+        self.options.orientation
+    }
+
+    /// TODO
+    pub async fn set_orientation(&mut self, orientation: Orientation) -> Result<(), DI::Error> {
+        self.madctl = self.madctl.with_orientation(orientation); // set orientation
+        self.di.write_command(self.madctl).await?;
+
+        Ok(())
+    }
+
+    /// TODO
+    pub async fn set_vertical_scroll_region(
+        &mut self,
+        top_fixed_area: u16,
+        bottom_fixed_area: u16,
+    ) -> Result<(), DI::Error> {
+        let rows = M::FRAMEBUFFER_SIZE.1;
+
+        let vscrdef = if top_fixed_area + bottom_fixed_area > rows {
+            dcs::SetScrollArea::new(rows, 0, 0)
+        } else {
+            dcs::SetScrollArea::new(
+                top_fixed_area,
+                rows - top_fixed_area - bottom_fixed_area,
+                bottom_fixed_area,
+            )
+        };
+
+        self.di.write_command(vscrdef).await
+    }
+
+    /// TODO
+    pub async fn set_vertical_scroll_offset(&mut self, offset: u16) -> Result<(), DI::Error> {
+        let vscad = dcs::SetScrollStart::new(offset);
+        self.di.write_command(vscad).await
+    }
+
+    /// TODO
+    pub fn release(self) -> (DI, M, Option<RST>) {
+        (self.di, self.model, self.rst)
+    }
+
+    /// TODO
+    pub async fn set_tearing_effect(
+        &mut self,
+        tearing_effect: options::TearingEffect,
+    ) -> Result<(), DI::Error> {
+        self.di
+            .write_command(dcs::SetTearingEffect::new(tearing_effect))
+            .await
+    }
+
+    /// TODO
+    pub fn is_sleeping(&self) -> bool {
+        self.sleeping
+    }
+
+    /// TODO
+    pub async fn sleep<D: DelayNs>(&mut self, delay: &mut D) -> Result<(), DI::Error> {
+        self.di.write_command(dcs::EnterSleepMode).await?;
+        // All supported models requires a 120ms delay before issuing other commands
+        delay.delay_us(120_000).await;
+        self.sleeping = true;
+        Ok(())
+    }
+
+    /// TODO
+    pub async fn wake<D: DelayNs>(&mut self, delay: &mut D) -> Result<(), DI::Error> {
+        self.di.write_command(dcs::ExitSleepMode).await?;
+        // ST7789 and st7735s have the highest minimal delay of 120ms
+        delay.delay_us(120_000).await;
+        self.sleeping = false;
+        Ok(())
+    }
+
+    // Sets the addre
+    fn store_address_window(&mut self, sx: u16, sy: u16, ex: u16, ey: u16) {
+        self.last_window_extents.x = (sx, ex);
+        self.last_window_extents.y = (sy, ey);
+        self.max_window_extents.apply_column_max(sx, ex);
+        self.max_window_extents.apply_page_max(sy, ey);
+    }
+
+    /// TODO
+    pub fn set_pixel(&mut self, x: u16, y: u16, color: M::ColorFormat) -> Result<(), DI::Error> {
+        self.set_pixels(x, y, x, y, core::iter::once(color))
+    }
+
+    /// TODO
+    pub fn set_pixels<T>(
+        &mut self,
+        sx: u16,
+        sy: u16,
+        ex: u16,
+        ey: u16,
+        pixels: T,
+    ) -> Result<(), DI::Error>
+    where
+        T: IntoIterator<Item = M::ColorFormat>,
+    {
+        self.store_address_window(sx, sy, ex, ey);
+
+        let mut bytes = M::ColorFormat::pixels_to_bytes(pixels).into_iter();
+        let mut lines = ExtentsRowIterator::default();
+
+        while let Some((start_index, end_index)) = lines.next(
+            &self.last_window_extents,
+            self.options.display_size(),
+            Self::pixel_bytes(),
+        ) {
+            for buf_byte in &mut self.buffer[start_index..end_index] {
+                if let Some(byte) = bytes.next() {
+                    *buf_byte = byte;
+                } else {
+                    break;
+                };
+            }
+        }
+
+        Ok(())
+    }
+
+    /// TODO
+    pub async fn flush(&mut self) -> Result<(), DI::Error> {
+        // set drawing window based on max_window_extents
+        let sca =
+            dcs::SetColumnAddress::new(self.max_window_extents.x.0, self.max_window_extents.x.1);
+        self.di.write_command(sca).await?;
+
+        let spa =
+            dcs::SetPageAddress::new(self.max_window_extents.y.0, self.max_window_extents.y.1);
+
+        self.di.write_command(spa).await?;
+
+        // draw area of max_window_extents from buffer
+        self.di.write_command(dcs::WriteMemoryStart).await?;
+
+        let mut lines = ExtentsRowIterator::default();
+        while let Some((start_index, end_index)) = lines.next(
+            &self.max_window_extents,
+            self.options.display_size(),
+            Self::pixel_bytes(),
+        ) {
+            self.di
+                .send_buffer(&self.buffer[start_index..end_index])
+                .await?;
+        }
+
+        // reset the max extents
+        self.max_window_extents = WindowExtents::default_max();
+        Ok(())
+    }
+
+    const fn pixel_bytes() -> usize {
+        2 // TODO!
+    }
+}
+
+impl<DI, M, RST> DrawTarget for DisplayAsync<'_, DI, M, RST>
+where
+    DI: InterfaceAsync,
+    M: Model,
+    M::ColorFormat: InterfacePixelFormat<DI::Word>,
+    RST: OutputPin,
+{
+    type Error = DI::Error;
+    type Color = M::ColorFormat;
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            let x = pixel.0.x as u16;
+            let y = pixel.0.y as u16;
+
+            self.set_pixel(x, y, pixel.1)?;
+        }
+
+        Ok(())
+    }
+
+    fn fill_contiguous<I>(&mut self, area: &Rectangle, colors: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Self::Color>,
+    {
+        let intersection = area.intersection(&self.bounding_box());
+        let Some(bottom_right) = intersection.bottom_right() else {
+            // No intersection -> nothing to draw
+            return Ok(());
+        };
+
+        // Unchecked casting to u16 cannot fail here because the values are
+        // clamped to the display size which always fits in an u16.
+        let sx = intersection.top_left.x as u16;
+        let sy = intersection.top_left.y as u16;
+        let ex = bottom_right.x as u16;
+        let ey = bottom_right.y as u16;
+
+        let count = intersection.size.width * intersection.size.height;
+
+        let mut colors = colors.into_iter();
+
+        if &intersection == area {
+            // Draw the original iterator if no edge overlaps the framebuffer
+            self.set_pixels(sx, sy, ex, ey, take_u32(colors, count))
+        } else {
+            // Skip pixels above and to the left of the intersection
+            let mut initial_skip = 0;
+            if intersection.top_left.y > area.top_left.y {
+                initial_skip += intersection.top_left.y.abs_diff(area.top_left.y) * area.size.width;
+            }
+            if intersection.top_left.x > area.top_left.x {
+                initial_skip += intersection.top_left.x.abs_diff(area.top_left.x);
+            }
+            if initial_skip > 0 {
+                nth_u32(&mut colors, initial_skip - 1);
+            }
+
+            // Draw only the pixels which don't overlap the edges of the framebuffer
+            let take_per_row = intersection.size.width;
+            let skip_per_row = area.size.width - intersection.size.width;
+            self.set_pixels(
+                sx,
+                sy,
+                ex,
+                ey,
+                take_u32(TakeSkip::new(colors, take_per_row, skip_per_row), count),
+            )
+        }
+    }
+
+    fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
+        let area = area.intersection(&self.bounding_box());
+        let Some(bottom_right) = area.bottom_right() else {
+            // No intersection -> nothing to draw
+            return Ok(());
+        };
+
+        let count = (area.size.width * area.size.height) as usize;
+
+        let sx = area.top_left.x as u16;
+        let sy = area.top_left.y as u16;
+        let ex = bottom_right.x as u16;
+        let ey = bottom_right.y as u16;
+
+        self.store_address_window(sx, sy, ex, ey);
+        self.set_pixels(sx, sy, ex, ey, core::iter::repeat_n(color, count))
+    }
+}
+
+impl<DI, MODEL, RST> OriginDimensions for DisplayAsync<'_, DI, MODEL, RST>
+where
+    DI: InterfaceAsync,
+    MODEL: Model,
+    MODEL::ColorFormat: InterfacePixelFormat<DI::Word>,
+    RST: OutputPin,
+{
+    fn size(&self) -> Size {
+        let ds = self.options.display_size();
+        let (width, height) = (u32::from(ds.0), u32::from(ds.1));
+        Size::new(width, height)
+    }
+}

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -1,0 +1,123 @@
+#[derive(Debug, Default)]
+pub struct WindowExtents {
+    pub x: (u16, u16),
+    pub y: (u16, u16),
+}
+
+impl WindowExtents {
+    pub fn default_max() -> Self {
+        Self {
+            x: (u16::MAX, 0),
+            y: (u16::MAX, 0),
+        }
+    }
+
+    pub fn apply_column_max(&mut self, sx: u16, ex: u16) {
+        self.x.0 = core::cmp::min(self.x.0, sx);
+        self.x.1 = core::cmp::max(self.x.1, ex);
+    }
+
+    pub fn apply_page_max(&mut self, sy: u16, ey: u16) {
+        self.y.0 = core::cmp::min(self.y.0, sy);
+        self.y.1 = core::cmp::max(self.y.1, ey);
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct ExtentsRowIterator(usize);
+
+impl ExtentsRowIterator {
+    pub fn next(
+        &mut self,
+        extents: &WindowExtents,
+        display_size: (u16, u16),
+        pixel_bytes: usize,
+    ) -> Option<(usize, usize)> {
+        if self.0 + extents.y.0 as usize > extents.y.1 as usize {
+            return None;
+        }
+
+        // these are all in pixel counts
+        let start_x = extents.x.0 as usize;
+        let start_y = extents.y.0 as usize + self.0;
+        let size_x = (extents.x.1 - extents.x.0 + 1) as usize;
+
+        // these are in byte counts
+        let start_index = (start_x + display_size.0 as usize * start_y) * pixel_bytes;
+        let end_index = start_index + (size_x * pixel_bytes);
+
+        self.0 += 1;
+        Some((start_index, end_index))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const PIXEL_BYTES: usize = 2;
+    const DISPLAY_SIZE: (u16, u16) = (240, 130);
+
+    #[test]
+    fn test_zero_extents_row_iterator() {
+        let extents = WindowExtents {
+            x: (0, 0),
+            y: (0, 0),
+        };
+
+        let mut iter = ExtentsRowIterator::default();
+
+        if let Some((start_index, end_index)) = iter.next(&extents, DISPLAY_SIZE, PIXEL_BYTES) {
+            assert_eq!(start_index, 0);
+            assert_eq!(end_index, 2);
+        } else {
+            panic!("iterator did not return a value");
+        }
+
+        assert_eq!(iter.next(&extents, DISPLAY_SIZE, PIXEL_BYTES), None);
+    }
+
+    #[test]
+    fn test_empty_extents_row_iterator() {
+        let extents = WindowExtents {
+            x: (44, 44),
+            y: (33, 33),
+        };
+
+        let mut iter = ExtentsRowIterator::default();
+
+        if let Some((start_index, end_index)) = iter.next(&extents, DISPLAY_SIZE, PIXEL_BYTES) {
+            assert_eq!(
+                start_index,
+                (33 * DISPLAY_SIZE.0 as usize + 44) * PIXEL_BYTES
+            );
+            assert_eq!(end_index, start_index + PIXEL_BYTES);
+        } else {
+            panic!("iterator did not return a value");
+        }
+
+        assert_eq!(iter.next(&extents, DISPLAY_SIZE, PIXEL_BYTES), None);
+    }
+
+    #[test]
+    fn test_rect_extents_row_iterator() {
+        let extents = WindowExtents {
+            x: (55, 57),
+            y: (33, 33),
+        };
+
+        let mut iter = ExtentsRowIterator::default();
+
+        if let Some((start_index, end_index)) = iter.next(&extents, DISPLAY_SIZE, PIXEL_BYTES) {
+            assert_eq!(
+                start_index,
+                (33 * DISPLAY_SIZE.0 as usize + 55) * PIXEL_BYTES
+            );
+            assert_eq!(end_index, start_index + 3 * PIXEL_BYTES);
+        } else {
+            panic!("iterator did not return a value");
+        }
+
+        assert_eq!(iter.next(&extents, DISPLAY_SIZE, PIXEL_BYTES), None);
+    }
+}

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -7,7 +7,6 @@ use embedded_graphics_core::{
 };
 use embedded_hal::digital::OutputPin;
 
-use crate::dcs::InterfaceExt;
 use crate::{dcs::BitsPerPixel, interface::Interface};
 use crate::{dcs::WriteMemoryStart, models::Model};
 use crate::{interface::InterfacePixelFormat, Display};
@@ -149,7 +148,7 @@ impl BitsPerPixel {
 }
 
 /// An iterator that alternately takes and skips elements of another iterator.
-struct TakeSkip<I> {
+pub(crate) struct TakeSkip<I> {
     iter: I,
     take: u32,
     take_remaining: u32,
@@ -184,12 +183,12 @@ impl<I: Iterator> Iterator for TakeSkip<I> {
 }
 
 #[cfg(not(target_pointer_width = "16"))]
-fn take_u32<I: Iterator>(iter: I, max_count: u32) -> impl Iterator<Item = I::Item> {
+pub(crate) fn take_u32<I: Iterator>(iter: I, max_count: u32) -> impl Iterator<Item = I::Item> {
     iter.take(max_count.try_into().unwrap())
 }
 
 #[cfg(target_pointer_width = "16")]
-fn take_u32<I: Iterator>(iter: I, max_count: u32) -> impl Iterator<Item = I::Item> {
+pub(crate) fn take_u32<I: Iterator>(iter: I, max_count: u32) -> impl Iterator<Item = I::Item> {
     let mut count = 0;
     iter.take_while(move |_| {
         count += 1;
@@ -198,12 +197,12 @@ fn take_u32<I: Iterator>(iter: I, max_count: u32) -> impl Iterator<Item = I::Ite
 }
 
 #[cfg(not(target_pointer_width = "16"))]
-fn nth_u32<I: Iterator>(mut iter: I, n: u32) -> Option<I::Item> {
+pub(crate) fn nth_u32<I: Iterator>(mut iter: I, n: u32) -> Option<I::Item> {
     iter.nth(n.try_into().unwrap())
 }
 
 #[cfg(target_pointer_width = "16")]
-fn nth_u32<I: Iterator>(mut iter: I, n: u32) -> Option<I::Item> {
+pub(crate) fn nth_u32<I: Iterator>(mut iter: I, n: u32) -> Option<I::Item> {
     for _ in 0..n {
         iter.next();
     }

--- a/src/init_engine.rs
+++ b/src/init_engine.rs
@@ -1,0 +1,136 @@
+use core::marker::PhantomData;
+
+use embedded_hal::delay::DelayNs;
+
+use crate::{
+    dcs::DcsCommand,
+    interface::{Interface, InterfaceAsync, InterfaceKind},
+    models::ModelInitError,
+};
+
+/// todo
+pub trait InitEngine {
+    // required for interface checks in Model::init
+    const INTERFACE_KIND: InterfaceKind;
+    type Error: core::fmt::Debug;
+    /// Queue a raw command with optional parameters
+    fn queue_command_raw(&mut self, command: u8, args: &[u8]) -> Result<(), Self::Error>;
+
+    fn queue_command(&mut self, command: impl DcsCommand) -> Result<(), Self::Error>;
+
+    fn queue_delay_us(&mut self, us: u32) -> Result<(), Self::Error>;
+
+    fn pop_command(&mut self) -> Option<QueuedInitCommand>;
+}
+
+pub struct InitEngineSync<'delay, DI, DELAY> {
+    di: DI,
+    delay: &'delay mut DELAY,
+}
+
+pub struct InitEngineAsync<DI> {
+    queue: heapless::Deque<QueuedInitCommand, 24>,
+    _di: PhantomData<DI>,
+}
+
+pub enum QueuedInitCommand {
+    RawDcs(u8, [u8; 16]),
+    Delay(u32),
+}
+
+impl<DC> From<DC> for QueuedInitCommand
+where
+    DC: DcsCommand,
+{
+    fn from(value: DC) -> Self {
+        let mut buf: [u8; 16] = [0; 16];
+        value.fill_params_buf(&mut buf);
+        Self::RawDcs(value.instruction(), buf)
+    }
+}
+
+impl<'delay, DI, DELAY> InitEngineSync<'delay, DI, DELAY>
+where
+    DI: Interface,
+    DELAY: DelayNs,
+{
+    pub fn new(di: DI, delay: &'delay mut DELAY) -> Self {
+        Self { di, delay }
+    }
+
+    pub fn release(self) -> DI {
+        self.di
+    }
+}
+
+impl<DI> InitEngineAsync<DI>
+where
+    DI: InterfaceAsync,
+{
+    pub fn new(_di: &DI) -> Self {
+        Self {
+            queue: heapless::Deque::new(),
+            _di: PhantomData,
+        }
+    }
+}
+
+impl<DI, DELAY> InitEngine for InitEngineSync<'_, DI, DELAY>
+where
+    DI: Interface,
+    DELAY: DelayNs,
+{
+    const INTERFACE_KIND: InterfaceKind = DI::KIND;
+    type Error = DI::Error;
+
+    fn queue_command(&mut self, command: impl DcsCommand) -> Result<(), Self::Error> {
+        self.di.write_command(command)
+    }
+
+    fn queue_command_raw(&mut self, command: u8, args: &[u8]) -> Result<(), Self::Error> {
+        self.di.send_command(command, args)
+    }
+
+    fn queue_delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
+        self.delay.delay_us(us);
+
+        Ok(())
+    }
+
+    fn pop_command(&mut self) -> Option<QueuedInitCommand> {
+        None
+    }
+}
+
+impl<DI> InitEngine for InitEngineAsync<DI>
+where
+    DI: InterfaceAsync,
+{
+    const INTERFACE_KIND: InterfaceKind = DI::KIND;
+    type Error = ModelInitError<DI::Error>;
+
+    fn queue_command(&mut self, command: impl DcsCommand) -> Result<(), Self::Error> {
+        self.queue
+            .push_back(command.into())
+            .map_err(|_| ModelInitError::InitEngineQueueFull)
+    }
+
+    fn queue_command_raw(&mut self, command: u8, args: &[u8]) -> Result<(), Self::Error> {
+        let mut arg_buf = [0u8; 16];
+        arg_buf[..args.len()].copy_from_slice(args);
+
+        self.queue
+            .push_back(QueuedInitCommand::RawDcs(command, arg_buf))
+            .map_err(|_| ModelInitError::InitEngineQueueFull)
+    }
+
+    fn queue_delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
+        self.queue
+            .push_back(QueuedInitCommand::Delay(us))
+            .map_err(|_| ModelInitError::InitEngineQueueFull)
+    }
+
+    fn pop_command(&mut self) -> Option<QueuedInitCommand> {
+        self.queue.pop_front()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,12 +105,12 @@
 //! display.clear(Rgb666::RED).unwrap();
 //! ```
 
-use dcs::InterfaceExt;
-
 pub mod interface;
 
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::OutputPin;
+
+mod init_engine;
 
 pub mod options;
 use interface::InterfacePixelFormat;
@@ -131,6 +131,10 @@ pub use test_image::TestImage;
 
 #[cfg(feature = "batch")]
 mod batch;
+
+mod display_async;
+mod framebuffer;
+pub use display_async::*;
 
 pub mod _troubleshooting;
 
@@ -386,89 +390,89 @@ where
     }
 }
 
-/// Mock implementations of embedded-hal and interface traits.
-///
-/// Do not use types in this module outside of doc tests.
-#[doc(hidden)]
-pub mod _mock {
-    use core::convert::Infallible;
+// / Mock implementations of embedded-hal and interface traits.
+// /
+// / Do not use types in this module outside of doc tests.
+// #[doc(hidden)]
+// pub mod _mock {
+//     use core::convert::Infallible;
 
-    use embedded_hal::{delay::DelayNs, digital, spi};
+//     use embedded_hal::{delay::DelayNs, digital, spi};
 
-    use crate::{
-        interface::{Interface, InterfaceKind},
-        models::ILI9341Rgb565,
-        Builder, Display, NoResetPin,
-    };
+//     use crate::{
+//         interface::{Interface, InterfaceKind},
+//         models::ILI9341Rgb565,
+//         Builder, Display, NoResetPin,
+//     };
 
-    pub fn new_mock_display() -> Display<MockDisplayInterface, ILI9341Rgb565, NoResetPin> {
-        Builder::new(ILI9341Rgb565, MockDisplayInterface)
-            .init(&mut MockDelay)
-            .unwrap()
-    }
+//     pub fn new_mock_display() -> Display<MockDisplayInterface, ILI9341Rgb565, NoResetPin> {
+//         Builder::new(ILI9341Rgb565, MockDisplayInterface)
+//             .init(&mut MockDelay)
+//             .unwrap()
+//     }
 
-    pub struct MockOutputPin;
+//     pub struct MockOutputPin;
 
-    impl digital::OutputPin for MockOutputPin {
-        fn set_low(&mut self) -> Result<(), Self::Error> {
-            Ok(())
-        }
+//     impl digital::OutputPin for MockOutputPin {
+//         fn set_low(&mut self) -> Result<(), Self::Error> {
+//             Ok(())
+//         }
 
-        fn set_high(&mut self) -> Result<(), Self::Error> {
-            Ok(())
-        }
-    }
+//         fn set_high(&mut self) -> Result<(), Self::Error> {
+//             Ok(())
+//         }
+//     }
 
-    impl digital::ErrorType for MockOutputPin {
-        type Error = core::convert::Infallible;
-    }
+//     impl digital::ErrorType for MockOutputPin {
+//         type Error = core::convert::Infallible;
+//     }
 
-    pub struct MockSpi;
+//     pub struct MockSpi;
 
-    impl spi::SpiDevice for MockSpi {
-        fn transaction(
-            &mut self,
-            _operations: &mut [spi::Operation<'_, u8>],
-        ) -> Result<(), Self::Error> {
-            Ok(())
-        }
-    }
+//     impl spi::SpiDevice for MockSpi {
+//         fn transaction(
+//             &mut self,
+//             _operations: &mut [spi::Operation<'_, u8>],
+//         ) -> Result<(), Self::Error> {
+//             Ok(())
+//         }
+//     }
 
-    impl spi::ErrorType for MockSpi {
-        type Error = core::convert::Infallible;
-    }
+//     impl spi::ErrorType for MockSpi {
+//         type Error = core::convert::Infallible;
+//     }
 
-    pub struct MockDelay;
+//     pub struct MockDelay;
 
-    impl DelayNs for MockDelay {
-        fn delay_ns(&mut self, _ns: u32) {}
-    }
+//     impl DelayNs for MockDelay {
+//         fn delay_ns(&mut self, _ns: u32) {}
+//     }
 
-    pub struct MockDisplayInterface;
+//     pub struct MockDisplayInterface;
 
-    impl Interface for MockDisplayInterface {
-        type Word = u8;
-        type Error = Infallible;
+//     impl Interface for MockDisplayInterface {
+//         type Word = u8;
+//         type Error = Infallible;
 
-        const KIND: InterfaceKind = InterfaceKind::Serial4Line;
+//         const KIND: InterfaceKind = InterfaceKind::Serial4Line;
 
-        fn send_command(&mut self, _command: u8, _args: &[u8]) -> Result<(), Self::Error> {
-            Ok(())
-        }
+//         fn send_command(&mut self, _command: u8, _args: &[u8]) -> Result<(), Self::Error> {
+//             Ok(())
+//         }
 
-        fn send_pixels<const N: usize>(
-            &mut self,
-            _pixels: impl IntoIterator<Item = [Self::Word; N]>,
-        ) -> Result<(), Self::Error> {
-            Ok(())
-        }
+//         fn send_pixels<const N: usize>(
+//             &mut self,
+//             _pixels: impl IntoIterator<Item = [Self::Word; N]>,
+//         ) -> Result<(), Self::Error> {
+//             Ok(())
+//         }
 
-        fn send_repeated_pixel<const N: usize>(
-            &mut self,
-            _pixel: [Self::Word; N],
-            _count: u32,
-        ) -> Result<(), Self::Error> {
-            Ok(())
-        }
-    }
-}
+//         fn send_repeated_pixel<const N: usize>(
+//             &mut self,
+//             _pixel: [Self::Word; N],
+//             _count: u32,
+//         ) -> Result<(), Self::Error> {
+//             Ok(())
+//         }
+//     }
+// }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,33 +1,34 @@
 //! Display models.
 
-use crate::{dcs::SetAddressMode, interface::Interface, options::ModelOptions, ConfigurationError};
+use crate::{
+    dcs::SetAddressMode, init_engine::InitEngine, options::ModelOptions, ConfigurationError,
+};
 use embedded_graphics_core::prelude::RgbColor;
-use embedded_hal::delay::DelayNs;
 
 // existing model implementations
-mod gc9107;
-mod gc9a01;
-mod ili9341;
-mod ili9342c;
-mod ili934x;
-mod ili9486;
-mod ili9488;
-mod ili948x;
-mod rm67162;
-mod st7735s;
+// mod gc9107;
+// mod gc9a01;
+// mod ili9341;
+// mod ili9342c;
+// mod ili934x;
+// mod ili9486;
+// mod ili9488;
+// mod ili948x;
+// mod rm67162;
+// mod st7735s;
 mod st7789;
-mod st7796;
+// mod st7796;
 
-pub use gc9107::*;
-pub use gc9a01::*;
-pub use ili9341::*;
-pub use ili9342c::*;
-pub use ili9486::*;
-pub use ili9488::*;
-pub use rm67162::*;
-pub use st7735s::*;
+// pub use gc9107::*;
+// pub use gc9a01::*;
+// pub use ili9341::*;
+// pub use ili9342c::*;
+// pub use ili9486::*;
+// pub use ili9488::*;
+// pub use rm67162::*;
+// pub use st7735s::*;
 pub use st7789::*;
-pub use st7796::*;
+// pub use st7796::*;
 
 /// Display model.
 pub trait Model {
@@ -39,24 +40,26 @@ pub trait Model {
 
     /// Initializes the display for this model with MADCTL from [crate::Display]
     /// and returns the value of MADCTL set by init
-    fn init<DELAY, DI>(
+    fn init<IE>(
         &mut self,
-        di: &mut DI,
-        delay: &mut DELAY,
         options: &ModelOptions,
-    ) -> Result<SetAddressMode, ModelInitError<DI::Error>>
+        ie: &mut IE,
+    ) -> Result<SetAddressMode, ModelInitError<IE::Error>>
     where
-        DELAY: DelayNs,
-        DI: Interface;
+        IE: InitEngine;
 }
 
 /// Error returned by [`Model::init`].
 ///
 /// This error type is used internally by implementations of the [`Model`]
 /// trait.
+#[derive(Debug)]
 pub enum ModelInitError<DiError> {
     /// Error caused by the display interface.
     Interface(DiError),
+
+    /// The init enine's queue, used for this Model's init, was too small
+    InitEngineQueueFull,
 
     /// Invalid configuration error.
     ///
@@ -72,67 +75,67 @@ impl<DiError> From<DiError> for ModelInitError<DiError> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use embedded_graphics::pixelcolor::Rgb565;
+// #[cfg(test)]
+// mod tests {
+//     use embedded_graphics::pixelcolor::Rgb565;
 
-    use crate::{
-        Builder,
-        _mock::{MockDelay, MockDisplayInterface},
-        interface::InterfaceKind,
-        ConfigurationError, InitError,
-    };
+//     use crate::{
+//         Builder,
+//         _mock::{MockDelay, MockDisplayInterface},
+//         interface::InterfaceKind,
+//         ConfigurationError, InitError,
+//     };
 
-    use super::*;
+//     use super::*;
 
-    struct OnlyOneKindModel(InterfaceKind);
+//     struct OnlyOneKindModel(InterfaceKind);
 
-    impl Model for OnlyOneKindModel {
-        type ColorFormat = Rgb565;
+//     impl Model for OnlyOneKindModel {
+//         type ColorFormat = Rgb565;
 
-        const FRAMEBUFFER_SIZE: (u16, u16) = (16, 16);
+//         const FRAMEBUFFER_SIZE: (u16, u16) = (16, 16);
 
-        fn init<DELAY, DI>(
-            &mut self,
-            _di: &mut DI,
-            _delay: &mut DELAY,
-            _options: &ModelOptions,
-        ) -> Result<SetAddressMode, ModelInitError<DI::Error>>
-        where
-            DELAY: DelayNs,
-            DI: Interface,
-        {
-            if DI::KIND != self.0 {
-                return Err(ModelInitError::InvalidConfiguration(
-                    ConfigurationError::UnsupportedInterface,
-                ));
-            }
+//         fn init<DELAY, DI>(
+//             &mut self,
+//             _di: &mut DI,
+//             _delay: &mut DELAY,
+//             _options: &ModelOptions,
+//         ) -> Result<SetAddressMode, ModelInitError<DI::Error>>
+//         where
+//             DELAY: DelayNs,
+//             DI: Interface,
+//         {
+//             if DI::KIND != self.0 {
+//                 return Err(ModelInitError::InvalidConfiguration(
+//                     ConfigurationError::UnsupportedInterface,
+//                 ));
+//             }
 
-            Ok(SetAddressMode::default())
-        }
-    }
+//             Ok(SetAddressMode::default())
+//         }
+//     }
 
-    #[test]
-    fn test_assert_interface_kind_serial() {
-        Builder::new(
-            OnlyOneKindModel(InterfaceKind::Serial4Line),
-            MockDisplayInterface,
-        )
-        .init(&mut MockDelay)
-        .unwrap();
-    }
+//     #[test]
+//     fn test_assert_interface_kind_serial() {
+//         Builder::new(
+//             OnlyOneKindModel(InterfaceKind::Serial4Line),
+//             MockDisplayInterface,
+//         )
+//         .init(&mut MockDelay)
+//         .unwrap();
+//     }
 
-    #[test]
-    fn test_assert_interface_kind_parallel() {
-        assert!(matches!(
-            Builder::new(
-                OnlyOneKindModel(InterfaceKind::Parallel8Bit),
-                MockDisplayInterface,
-            )
-            .init(&mut MockDelay),
-            Err(InitError::InvalidConfiguration(
-                ConfigurationError::UnsupportedInterface
-            ))
-        ));
-    }
-}
+//     #[test]
+//     fn test_assert_interface_kind_parallel() {
+//         assert!(matches!(
+//             Builder::new(
+//                 OnlyOneKindModel(InterfaceKind::Parallel8Bit),
+//                 MockDisplayInterface,
+//             )
+//             .init(&mut MockDelay),
+//             Err(InitError::InvalidConfiguration(
+//                 ConfigurationError::UnsupportedInterface
+//             ))
+//         ));
+//     }
+// }

--- a/tests/external.rs
+++ b/tests/external.rs
@@ -1,55 +1,55 @@
-use embedded_graphics_core::pixelcolor::Rgb565;
-use embedded_hal::delay::DelayNs;
-use mipidsi::{
-    dcs::{
-        BitsPerPixel, EnterNormalMode, ExitSleepMode, InterfaceExt, PixelFormat, SetAddressMode,
-        SetDisplayOn, SetInvertMode, SetPixelFormat,
-    },
-    interface::Interface,
-    models::{Model, ModelInitError},
-    options::ModelOptions,
-};
+// use embedded_graphics_core::pixelcolor::Rgb565;
+// use embedded_hal::delay::DelayNs;
+// use mipidsi::{
+//     dcs::{
+//         BitsPerPixel, EnterNormalMode, ExitSleepMode, InterfaceExt, PixelFormat, SetAddressMode,
+//         SetDisplayOn, SetInvertMode, SetPixelFormat,
+//     },
+//     interface::Interface,
+//     models::{Model, ModelInitError},
+//     options::ModelOptions,
+// };
 
-/// Copy of the ST7789 driver to check if it can also be implemented in another
-/// crate.
-pub struct ExternalST7789;
+// /// Copy of the ST7789 driver to check if it can also be implemented in another
+// /// crate.
+// pub struct ExternalST7789;
 
-impl Model for ExternalST7789 {
-    type ColorFormat = Rgb565;
-    const FRAMEBUFFER_SIZE: (u16, u16) = (240, 320);
+// impl Model for ExternalST7789 {
+//     type ColorFormat = Rgb565;
+//     const FRAMEBUFFER_SIZE: (u16, u16) = (240, 320);
 
-    fn init<DELAY, DI>(
-        &mut self,
-        di: &mut DI,
-        delay: &mut DELAY,
-        options: &ModelOptions,
-    ) -> Result<SetAddressMode, ModelInitError<DI::Error>>
-    where
-        DELAY: DelayNs,
-        DI: Interface,
-    {
-        let madctl = SetAddressMode::from(options);
+//     fn init<DELAY, DI>(
+//         &mut self,
+//         di: &mut DI,
+//         delay: &mut DELAY,
+//         options: &ModelOptions,
+//     ) -> Result<SetAddressMode, ModelInitError<DI::Error>>
+//     where
+//         DELAY: DelayNs,
+//         DI: Interface,
+//     {
+//         let madctl = SetAddressMode::from(options);
 
-        delay.delay_us(150_000);
+//         delay.delay_us(150_000);
 
-        di.write_command(ExitSleepMode)?;
-        delay.delay_us(10_000);
+//         di.write_command(ExitSleepMode)?;
+//         delay.delay_us(10_000);
 
-        // set hw scroll area based on framebuffer size
-        di.write_command(madctl)?;
+//         // set hw scroll area based on framebuffer size
+//         di.write_command(madctl)?;
 
-        di.write_command(SetInvertMode::new(options.invert_colors))?;
+//         di.write_command(SetInvertMode::new(options.invert_colors))?;
 
-        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
-        di.write_command(SetPixelFormat::new(pf))?;
-        delay.delay_us(10_000);
-        di.write_command(EnterNormalMode)?;
-        delay.delay_us(10_000);
-        di.write_command(SetDisplayOn)?;
+//         let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+//         di.write_command(SetPixelFormat::new(pf))?;
+//         delay.delay_us(10_000);
+//         di.write_command(EnterNormalMode)?;
+//         delay.delay_us(10_000);
+//         di.write_command(SetDisplayOn)?;
 
-        // DISPON requires some time otherwise we risk SPI data issues
-        delay.delay_us(120_000);
+//         // DISPON requires some time otherwise we risk SPI data issues
+//         delay.delay_us(120_000);
 
-        Ok(madctl)
-    }
-}
+//         Ok(madctl)
+//     }
+// }


### PR DESCRIPTION
Supersedes #173 by implementing a `DisplayAsync` via:
1. Refactoring `Model::init` to take a `InitEngine` which then decides what to do with the init commands and delay calls
2. Adding a sync/direct and an async/buffering `InitEngine`
3. Adding a `InterfaceAsync` to complement `Interface` using frame buffering and async flushing
4. Adding `Builder::init_async` to make use of the new async setups
5. Implementing `DisplayAsync` using the new tools
6. Moved `InterfaceExt` into `Interface` directly for simplicity