### PR TITLE
Adding defmt::Format support to interface errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mipidsi"
 description = "MIPI Display Command Set compatible generic driver"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Ales Katona <almindor@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -12,6 +12,7 @@ documentation = "https://docs.rs/mipidsi"
 rust-version = "1.75"
 
 [dependencies]
+defmt = { version = "1.0.1", optional = true }
 embedded-graphics-core = "0.4.0"
 embedded-hal = "1.0.0"
 
@@ -25,6 +26,7 @@ embedded-graphics = "0.8.1"
 [features]
 default = ["batch"]
 batch = ["heapless"]
+defmt = ["dep:defmt", "embedded-hal/defmt-03"]
 
 [workspace]
 members = ["mipidsi-async"]

--- a/src/interface/parallel.rs
+++ b/src/interface/parallel.rs
@@ -1,5 +1,8 @@
 use embedded_hal::digital::OutputPin;
 
+#[cfg(feature = "defmt")]
+use defmt::Format;
+
 use super::{Interface, InterfaceKind};
 
 /// This trait represents the data pins of a parallel bus.
@@ -143,6 +146,7 @@ generic_bus! {
 }
 
 /// Parallel interface error
+#[cfg_attr(feature = "defmt", derive(Format))]
 #[derive(Clone, Copy, Debug)]
 pub enum ParallelError<BUS, DC, WR> {
     /// Bus error

--- a/src/interface/spi.rs
+++ b/src/interface/spi.rs
@@ -1,8 +1,12 @@
 use embedded_hal::{digital::OutputPin, spi::SpiDevice};
 
+#[cfg(feature = "defmt")]
+use defmt::Format;
+
 use super::{Interface, InterfaceKind};
 
 /// Spi interface error
+#[cfg_attr(feature = "defmt", derive(Format))]
 #[derive(Clone, Copy, Debug)]
 pub enum SpiError<SPI, DC> {
     /// SPI bus error


### PR DESCRIPTION
Thank you for mipidsi.

Would it be possible to add feature gated defmt::Format support to the interface errors?

This pull request adds defmt::Format support to the SPI and parallel interface errors. The support is gated behind the feature "defmt". The feature enables "defmt" support in mipidsi. In addition, it enables embedded-hal's defmt support so that embedded-hal's ErrorKind error will be sure to have defmt::Format support. It does not enable embedded-graphics-core's defmt support because the SPI and parallel interface errors do not appear to have any dependency on embedded-graphics-core.