### PR TITLE
Add defmt::Format derives whenever there is a Debug derive.

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -69,6 +69,7 @@ type BlockColors<C> = heapless::Vec<C, MAX_BLOCK_SIZE>;
 
 /// Iterator for each Pixel Row in the pixel data. A Pixel Row consists of contiguous pixels on the same row.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RowIterator<C, P>
 where
     C: PixelColor,
@@ -90,6 +91,7 @@ where
 
 /// Iterator for each Pixel Block in the pixel data. A Pixel Block consists of contiguous Pixel Rows with the same start and end column number.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BlockIterator<C, R>
 where
     C: PixelColor,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -203,6 +203,7 @@ where
 
 /// Error returned by [`Builder::init`].
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum InitError<DI, P> {
     /// Error caused by the display interface.
     Interface(DI),
@@ -221,6 +222,7 @@ pub enum InitError<DI, P> {
 /// Specifics of [InitError::InvalidConfiguration] if configuration was found invalid
 #[non_exhaustive]
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ConfigurationError {
     /// Unsupported interface kind.
     ///

--- a/src/dcs/set_address_mode.rs
+++ b/src/dcs/set_address_mode.rs
@@ -9,6 +9,7 @@ use super::DcsCommand;
 
 /// Set Address Mode
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SetAddressMode(u8);
 
 impl SetAddressMode {

--- a/src/dcs/set_column_address.rs
+++ b/src/dcs/set_column_address.rs
@@ -4,6 +4,7 @@ use super::DcsCommand;
 
 /// Set Column Address
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SetColumnAddress {
     start_column: u16,
     end_column: u16,

--- a/src/dcs/set_invert_mode.rs
+++ b/src/dcs/set_invert_mode.rs
@@ -4,6 +4,7 @@ use super::DcsCommand;
 
 /// Set Invert Mode
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SetInvertMode(ColorInversion);
 
 impl SetInvertMode {

--- a/src/dcs/set_page_address.rs
+++ b/src/dcs/set_page_address.rs
@@ -4,6 +4,7 @@ use super::DcsCommand;
 
 /// Set Page Address
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SetPageAddress {
     start_row: u16,
     end_row: u16,

--- a/src/dcs/set_pixel_format.rs
+++ b/src/dcs/set_pixel_format.rs
@@ -4,6 +4,7 @@ use super::DcsCommand;
 
 /// Set Pixel Format
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SetPixelFormat(PixelFormat);
 
 impl SetPixelFormat {
@@ -28,6 +29,7 @@ impl DcsCommand for SetPixelFormat {
 /// Bits per pixel for DBI and DPI fields of [PixelFormat]
 ///
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum BitsPerPixel {
     /// 3 bits per pixel.
@@ -48,6 +50,7 @@ pub enum BitsPerPixel {
 /// Defines pixel format as combination of DPI and DBI
 ///
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PixelFormat {
     dpi: BitsPerPixel,
     dbi: BitsPerPixel,

--- a/src/dcs/set_scroll_area.rs
+++ b/src/dcs/set_scroll_area.rs
@@ -4,6 +4,7 @@ use super::DcsCommand;
 
 /// Set Scroll Area
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SetScrollArea {
     tfa: u16,
     vsa: u16,

--- a/src/dcs/set_scroll_start.rs
+++ b/src/dcs/set_scroll_start.rs
@@ -4,6 +4,7 @@ use super::DcsCommand;
 
 /// Set Scroll Start
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SetScrollStart(u16);
 
 impl SetScrollStart {

--- a/src/dcs/set_tearing_effect.rs
+++ b/src/dcs/set_tearing_effect.rs
@@ -4,6 +4,7 @@ use super::DcsCommand;
 
 /// Set Tearing Effect
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SetTearingEffect(TearingEffect);
 
 impl SetTearingEffect {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -158,6 +158,7 @@ impl InterfacePixelFormat<u16> for Rgb565 {
 /// Specifies the kind of physical connection to the display controller that is
 /// supported by this interface.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum InterfaceKind {
     /// Serial interface with data/command pin.

--- a/src/interface/parallel.rs
+++ b/src/interface/parallel.rs
@@ -1,8 +1,5 @@
 use embedded_hal::digital::OutputPin;
 
-#[cfg(feature = "defmt")]
-use defmt::Format;
-
 use super::{Interface, InterfaceKind};
 
 /// This trait represents the data pins of a parallel bus.
@@ -146,8 +143,8 @@ generic_bus! {
 }
 
 /// Parallel interface error
-#[cfg_attr(feature = "defmt", derive(Format))]
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ParallelError<BUS, DC, WR> {
     /// Bus error
     Bus(BUS),

--- a/src/interface/spi.rs
+++ b/src/interface/spi.rs
@@ -1,13 +1,10 @@
 use embedded_hal::{digital::OutputPin, spi::SpiDevice};
 
-#[cfg(feature = "defmt")]
-use defmt::Format;
-
 use super::{Interface, InterfaceKind};
 
 /// Spi interface error
-#[cfg_attr(feature = "defmt", derive(Format))]
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SpiError<SPI, DC> {
     /// SPI bus error
     Spi(SPI),

--- a/src/models.rs
+++ b/src/models.rs
@@ -202,6 +202,8 @@ pub trait Model {
 ///
 /// This error type is used internally by implementations of the [`Model`]
 /// trait.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ModelInitError<DiError> {
     /// Error caused by the display interface.
     Interface(DiError),

--- a/src/options.rs
+++ b/src/options.rs
@@ -64,6 +64,7 @@ impl ModelOptions {
 
 /// Color inversion.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ColorInversion {
     /// Normal colors.
     Normal,
@@ -79,6 +80,7 @@ impl Default for ColorInversion {
 
 /// Vertical refresh order.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum VerticalRefreshOrder {
     /// Refresh from top to bottom.
     TopToBottom,
@@ -105,6 +107,7 @@ impl VerticalRefreshOrder {
 
 /// Horizontal refresh order.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum HorizontalRefreshOrder {
     /// Refresh from left to right.
     LeftToRight,
@@ -133,6 +136,7 @@ impl HorizontalRefreshOrder {
 ///
 /// Defaults to left to right, top to bottom.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RefreshOrder {
     /// Vertical refresh order.
     pub vertical: VerticalRefreshOrder,
@@ -170,6 +174,7 @@ impl RefreshOrder {
 
 /// Tearing effect output setting.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TearingEffect {
     /// Disable output.
     Off,
@@ -181,6 +186,7 @@ pub enum TearingEffect {
 
 /// Subpixel order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ColorOrder {
     /// RGB subpixel order.
     Rgb,

--- a/src/options/orientation.rs
+++ b/src/options/orientation.rs
@@ -1,5 +1,6 @@
 /// Display rotation.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Rotation {
     /// No rotation.
     Deg0,
@@ -63,6 +64,7 @@ impl Rotation {
 ///
 /// The error type returned by [`Rotation::try_from_degree`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct InvalidAngleError;
 
 /// Display orientation.
@@ -95,6 +97,7 @@ pub struct InvalidAngleError;
 /// ```
 ///
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Orientation {
     /// Rotation.
     pub rotation: Rotation,
@@ -170,6 +173,7 @@ impl Default for Orientation {
 /// A memory mapping describes how a framebuffer is mapped to the physical
 /// row and columns of a display.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct MemoryMapping {
     /// Rows and columns are swapped.
     pub swap_rows_and_columns: bool,


### PR DESCRIPTION
As little while ago I summited a pull request to add defmt support to interface errors. As I have improved the error handling in my project, I have found that I needed more structs/enums to have defmt support. For example, I needed defmt support for InitError. So, I added defmt support wherever there was Debug support in hopes that would catch everything.