### PR TITLE
Support Bgr565 as used by the Cheap Yellow Display

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,7 +1,7 @@
 //! Interface traits and implementations
 
 mod spi;
-use embedded_graphics_core::pixelcolor::{Rgb565, Rgb666, RgbColor};
+use embedded_graphics_core::pixelcolor::{Bgr565, Rgb565, Rgb666, RgbColor};
 pub use spi::*;
 
 mod parallel;
@@ -80,6 +80,9 @@ fn rgb565_to_u16(pixel: Rgb565) -> [u16; 1] {
 fn rgb666_to_bytes(pixel: Rgb666) -> [u8; 3] {
     [pixel.r(), pixel.g(), pixel.b()].map(|x| x << 2)
 }
+fn bgr565_to_bytes(pixel: Bgr565) -> [u8; 2] {
+    embedded_graphics_core::pixelcolor::raw::ToBytes::to_be_bytes(pixel)
+}
 
 /// This is an implementation detail, it should not be implemented or used outside this crate
 pub trait InterfacePixelFormat<Word> {
@@ -116,6 +119,23 @@ impl InterfacePixelFormat<u8> for Rgb565 {
         count: u32,
     ) -> Result<(), DI::Error> {
         di.send_repeated_pixel(rgb565_to_bytes(pixel), count)
+    }
+}
+
+impl InterfacePixelFormat<u8> for Bgr565 {
+    fn send_pixels<DI: Interface<Word = u8>>(
+        di: &mut DI,
+        pixels: impl IntoIterator<Item = Self>,
+    ) -> Result<(), DI::Error> {
+        di.send_pixels(pixels.into_iter().map(bgr565_to_bytes))
+    }
+
+    fn send_repeated_pixel<DI: Interface<Word = u8>>(
+        di: &mut DI,
+        pixel: Self,
+        count: u32,
+    ) -> Result<(), DI::Error> {
+        di.send_repeated_pixel(bgr565_to_bytes(pixel), count)
     }
 }
 

--- a/src/models/ili9341.rs
+++ b/src/models/ili9341.rs
@@ -1,4 +1,4 @@
-use embedded_graphics_core::pixelcolor::{Rgb565, Rgb666};
+use embedded_graphics_core::pixelcolor::{Bgr565, Rgb565, Rgb666};
 use embedded_hal::delay::DelayNs;
 
 use crate::{
@@ -12,11 +12,42 @@ use crate::{
 /// ILI9341 display in Rgb565 color mode.
 pub struct ILI9341Rgb565;
 
+/// ILI9341 display in Bgr565 color mode.
+pub struct ILI9341Bgr565;
+
 /// ILI9341 display in Rgb666 color mode.
 pub struct ILI9341Rgb666;
 
 impl Model for ILI9341Rgb565 {
     type ColorFormat = Rgb565;
+    const FRAMEBUFFER_SIZE: (u16, u16) = (240, 320);
+
+    fn init<DELAY, DI>(
+        &mut self,
+        di: &mut DI,
+        delay: &mut DELAY,
+        options: &ModelOptions,
+    ) -> Result<SetAddressMode, ModelInitError<DI::Error>>
+    where
+        DELAY: DelayNs,
+        DI: Interface,
+    {
+        if !matches!(
+            DI::KIND,
+            InterfaceKind::Serial4Line | InterfaceKind::Parallel8Bit | InterfaceKind::Parallel16Bit
+        ) {
+            return Err(ModelInitError::InvalidConfiguration(
+                ConfigurationError::UnsupportedInterface,
+            ));
+        }
+
+        let pf = PixelFormat::with_all(BitsPerPixel::from_rgb_color::<Self::ColorFormat>());
+        ili934x::init_common(di, delay, options, pf).map_err(Into::into)
+    }
+}
+
+impl Model for ILI9341Bgr565 {
+    type ColorFormat = Bgr565;
     const FRAMEBUFFER_SIZE: (u16, u16) = (240, 320);
 
     fn init<DELAY, DI>(


### PR DESCRIPTION
Not much to say about this one, the CYD is pretty popular so this would be nice to upstream. Tested of course (and that's the reason I didn't copy & past implement other Bgr variants just to be safe).